### PR TITLE
feat(log): record cleanup runs to jsonl log

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,17 @@ clean-history --quiet
 
 ## Cleanup log
 
-Every run (dry-run or real) appends one JSON line to `~/.zsh_history_cleanup.log`:
+Every run (dry-run or real) appends one JSON line to `~/.zsh_history_cleanup.log`
+(created with mode `0600` on first write, since entries embed command text):
 
 ```json
 {"timestamp": "...", "dry_run": false, "settings": {...}, "total_lines": 858,
  "removed_count": 84, "reason_counts": {"Duplicate": 70, ...},
  "removals": [{"line": 56, "reason": "Failed similar to '...'", "command": "..."}, ...]}
 ```
+
+`removals[].line` is the **0-based index** into the parsed `~/.zsh_history`
+file (matches Python's `enumerate`, so the first command is `0`).
 
 Use `clean-history-log` for a quick summary, `clean-history-log --full` for the raw
 JSONL, or pipe through `jq` for analytics (`jq '.reason_counts | to_entries[]'`,

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ source ~/.zsh-clean-history/zsh-clean-history.plugin.zsh
 - `clean-history` - Run cleanup now
 - `clean-history-stats` - Show stats without cleaning (dry run)
 - `clean-history-info` - Show plugin configuration and commands
+- `clean-history-log [N]` - Show summary of last N runs (default 5); pass `--full` for raw JSONL
 
 ### Configuration
 
@@ -116,6 +117,22 @@ clean-history --quiet
 - `--rare-threshold INT` - Override rare threshold
 - `--dry-run` - Show what would be removed without changing history
 - `--quiet` / `-q` - Minimal output
+- `--no-log` - Skip writing this run to `~/.zsh_history_cleanup.log`
+
+## Cleanup log
+
+Every run (dry-run or real) appends one JSON line to `~/.zsh_history_cleanup.log`:
+
+```json
+{"timestamp": "...", "dry_run": false, "settings": {...}, "total_lines": 858,
+ "removed_count": 84, "reason_counts": {"Duplicate": 70, ...},
+ "removals": [{"line": 56, "reason": "Failed similar to '...'", "command": "..."}, ...]}
+```
+
+Use `clean-history-log` for a quick summary, `clean-history-log --full` for the raw
+JSONL, or pipe through `jq` for analytics (`jq '.reason_counts | to_entries[]'`,
+trend success/failure rates, audit which commands were dropped, etc.). Pass
+`--no-log` to opt out for a single run.
 
 ## Requirements
 

--- a/clean_history.py
+++ b/clean_history.py
@@ -13,6 +13,7 @@ import contextlib
 import json
 import re
 import shutil
+import sys
 
 from collections import Counter, defaultdict
 from dataclasses import dataclass
@@ -80,7 +81,8 @@ def similarity(a: str, b: str) -> float:
 
 def get_base_command(cmd: str) -> str:
     """Extract base command (first word) for grouping."""
-    return cmd.split(maxsplit=1)[0] if cmd.split() else cmd
+    parts = cmd.split(maxsplit=1)
+    return parts[0] if parts else cmd
 
 
 def find_duplicate_indices(
@@ -333,8 +335,18 @@ def _write_log(
         "removals": removals,
     }
 
-    with LOG_FILE.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    # Log writes are best-effort: cleanup may have already mutated history,
+    # so a failure here (read-only HOME, full disk, etc.) must not crash.
+    # Mirror ~/.zsh_history's 0o600 mode since the log embeds command text.
+    try:
+        first_create = not LOG_FILE.exists()
+        with LOG_FILE.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        if first_create:
+            with contextlib.suppress(OSError):
+                LOG_FILE.chmod(0o600)
+    except OSError as exc:
+        sys.stderr.write(f"warning: could not write {LOG_FILE}: {exc}\n")
 
 
 def main() -> None:

--- a/clean_history.py
+++ b/clean_history.py
@@ -10,17 +10,20 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import json
 import re
 import shutil
 
 from collections import Counter, defaultdict
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from difflib import SequenceMatcher
 from pathlib import Path
 
 
 HISTORY_FILE = Path.home() / ".zsh_history"
 EXIT_FILE = Path.home() / ".zsh_history_exits"
+LOG_FILE = Path.home() / ".zsh_history_cleanup.log"
 BACKUP_SUFFIX = ".backup"
 SAMPLE_SIZE = 20  # Number of sample removals to show
 
@@ -77,7 +80,7 @@ def similarity(a: str, b: str) -> float:
 
 def get_base_command(cmd: str) -> str:
     """Extract base command (first word) for grouping."""
-    return cmd.split()[0] if cmd.split() else cmd
+    return cmd.split(maxsplit=1)[0] if cmd.split() else cmd
 
 
 def find_duplicate_indices(
@@ -279,6 +282,11 @@ def _parse_arguments() -> tuple[CleaningSettings, argparse.Namespace]:
         action="store_true",
         help="Remove rare command variants (default: keep them)",
     )
+    parser.add_argument(
+        "--no-log",
+        action="store_true",
+        help="Skip appending run summary to ~/.zsh_history_cleanup.log",
+    )
 
     args = parser.parse_args()
 
@@ -289,6 +297,44 @@ def _parse_arguments() -> tuple[CleaningSettings, argparse.Namespace]:
     )
 
     return settings, args
+
+
+def _write_log(
+    args: argparse.Namespace,
+    settings: CleaningSettings,
+    total_lines: int,
+    removal_reasons: dict[int, str],
+    cmd_to_lines: dict[str, list[int]],
+) -> None:
+    """Append one JSONL entry summarising this run."""
+    if args.no_log:
+        return
+
+    idx_to_cmd: dict[int, str] = {
+        idx: cmd for cmd, indices in cmd_to_lines.items() for idx in indices
+    }
+
+    removals = [
+        {"line": idx, "reason": reason, "command": idx_to_cmd.get(idx, "")}
+        for idx, reason in sorted(removal_reasons.items())
+    ]
+
+    entry = {
+        "timestamp": datetime.now(UTC).isoformat(timespec="seconds"),
+        "dry_run": args.dry_run,
+        "settings": {
+            "similarity": settings.similarity_threshold,
+            "rare_threshold": settings.rare_threshold,
+            "remove_rare": settings.remove_rare,
+        },
+        "total_lines": total_lines,
+        "removed_count": len(removal_reasons),
+        "reason_counts": dict(Counter(removal_reasons.values())),
+        "removals": removals,
+    }
+
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 
 def main() -> None:
@@ -326,6 +372,8 @@ def main() -> None:
             for idx, line in enumerate(all_lines):
                 if idx not in lines_to_remove:
                     f.write(line + "\n")
+
+    _write_log(args, settings, len(all_lines), _removal_reasons, cmd_to_lines)
 
     if removed_count > 0 and not args.quiet:
         # Count removals by reason

--- a/test_clean_history.py
+++ b/test_clean_history.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """Tests for clean_history.py."""
 
+import argparse
+import json
+
 from collections import Counter, defaultdict
+from pathlib import Path
 from unittest.mock import mock_open, patch
 
 import pytest
@@ -14,6 +18,7 @@ from clean_history import (
     _parse_history_file,
     _remove_failed_similar_commands,
     _remove_rare_variants,
+    _write_log,
     find_duplicate_indices,
     get_base_command,
     load_exit_codes,
@@ -455,7 +460,7 @@ def test_main_dry_run(capsys: pytest.CaptureFixture[str]) -> None:
     history_data = ": 1234567890:0;git status\n: 1234567891:0;git status\n"
     exit_data = "1234567890:0\n1234567891:0\n"
 
-    with patch("sys.argv", ["clean_history.py", "--dry-run"]), patch(
+    with patch("sys.argv", ["clean_history.py", "--dry-run", "--no-log"]), patch(
         "clean_history.HISTORY_FILE"
     ) as mock_history, patch("clean_history.EXIT_FILE") as mock_exit:
         mock_history.open = mock_open(read_data=history_data)
@@ -474,7 +479,7 @@ def test_main_no_removals(capsys: pytest.CaptureFixture[str]) -> None:
     history_data = ": 1234567890:0;git status\n"
     exit_data = "1234567890:0\n"
 
-    with patch("sys.argv", ["clean_history.py"]), patch(
+    with patch("sys.argv", ["clean_history.py", "--no-log"]), patch(
         "clean_history.HISTORY_FILE"
     ) as mock_history, patch("clean_history.EXIT_FILE") as mock_exit, patch("shutil.copy2"):
         mock_history.open = mock_open(read_data=history_data)
@@ -492,7 +497,7 @@ def test_main_quiet_mode(capsys: pytest.CaptureFixture[str]) -> None:
     history_data = ": 1234567890:0;git status\n: 1234567891:0;git status\n"
     exit_data = "1234567890:0\n1234567891:0\n"
 
-    with patch("sys.argv", ["clean_history.py", "--quiet", "--dry-run"]), patch(
+    with patch("sys.argv", ["clean_history.py", "--quiet", "--dry-run", "--no-log"]), patch(
         "clean_history.HISTORY_FILE"
     ) as mock_history, patch("clean_history.EXIT_FILE") as mock_exit:
         mock_history.open = mock_open(read_data=history_data)
@@ -510,7 +515,7 @@ def test_main_creates_backup() -> None:
     history_data = ": 1234567890:0;git status\n"
     exit_data = "1234567890:0\n"
 
-    with patch("sys.argv", ["clean_history.py"]), patch(
+    with patch("sys.argv", ["clean_history.py", "--no-log"]), patch(
         "clean_history.HISTORY_FILE"
     ) as mock_history, patch("clean_history.EXIT_FILE") as mock_exit, patch(
         "shutil.copy2"
@@ -543,3 +548,96 @@ def test_main_writes_cleaned_history() -> None:
     handle = mock_file_handle()
     written_lines = [call.args[0] for call in handle.write.call_args_list]
     assert len(written_lines) == 2
+
+
+def test_write_log_skipped_with_no_log_flag(tmp_path: Path) -> None:
+    """When --no-log is set, no log file is written."""
+    log_path = tmp_path / "cleanup.log"
+
+    args = argparse.Namespace(no_log=True, dry_run=True)
+    settings = CleaningSettings(similarity_threshold=0.8, rare_threshold=3, remove_rare=False)
+
+    with patch("clean_history.LOG_FILE", log_path):
+        _write_log(args, settings, total_lines=10, removal_reasons={}, cmd_to_lines={})
+
+    assert not log_path.exists()
+
+
+def test_write_log_writes_jsonl_entry(tmp_path: Path) -> None:
+    """A run produces one well-formed JSONL line with all expected fields."""
+    log_path = tmp_path / "cleanup.log"
+
+    args = argparse.Namespace(no_log=False, dry_run=True)
+    settings = CleaningSettings(similarity_threshold=0.85, rare_threshold=2, remove_rare=True)
+    cmd_to_lines = {"git statsu": [3], "git status": [1, 2]}
+    removal_reasons = {3: "Failed similar to 'git status'"}
+
+    with patch("clean_history.LOG_FILE", log_path):
+        _write_log(
+            args,
+            settings,
+            total_lines=42,
+            removal_reasons=removal_reasons,
+            cmd_to_lines=cmd_to_lines,
+        )
+
+    lines = [line for line in log_path.read_text().splitlines() if line.strip()]
+    assert len(lines) == 1
+
+    entry = json.loads(lines[0])
+    assert entry["dry_run"] is True
+    assert entry["total_lines"] == 42
+    assert entry["removed_count"] == 1
+    assert entry["settings"] == {
+        "similarity": 0.85,
+        "rare_threshold": 2,
+        "remove_rare": True,
+    }
+    assert entry["reason_counts"] == {"Failed similar to 'git status'": 1}
+    assert entry["removals"] == [
+        {"line": 3, "reason": "Failed similar to 'git status'", "command": "git statsu"},
+    ]
+    assert "timestamp" in entry
+
+
+def test_write_log_appends_across_runs(tmp_path: Path) -> None:
+    """Each call appends a new line so the log accumulates over time."""
+    log_path = tmp_path / "cleanup.log"
+
+    args = argparse.Namespace(no_log=False, dry_run=True)
+    settings = CleaningSettings(similarity_threshold=0.8, rare_threshold=3, remove_rare=False)
+
+    with patch("clean_history.LOG_FILE", log_path):
+        _write_log(args, settings, total_lines=10, removal_reasons={}, cmd_to_lines={})
+        _write_log(args, settings, total_lines=11, removal_reasons={}, cmd_to_lines={})
+
+    lines = [line for line in log_path.read_text().splitlines() if line.strip()]
+    assert len(lines) == 2
+    assert json.loads(lines[0])["total_lines"] == 10
+    assert json.loads(lines[1])["total_lines"] == 11
+
+
+def test_main_writes_log_entry(tmp_path: Path) -> None:
+    """main() produces a log entry by default; record reflects what was processed."""
+    log_path = tmp_path / "cleanup.log"
+    history_data = ": 1234567890:0;git status\n: 1234567891:0;git status\n"
+    exit_data = "1234567890:0\n1234567891:0\n"
+
+    with patch("sys.argv", ["clean_history.py", "--dry-run"]), patch(
+        "clean_history.HISTORY_FILE"
+    ) as mock_history, patch("clean_history.EXIT_FILE") as mock_exit, patch(
+        "clean_history.LOG_FILE", log_path
+    ):
+        mock_history.open = mock_open(read_data=history_data)
+        mock_exit.exists.return_value = True
+        mock_exit.open = mock_open(read_data=exit_data)
+
+        main()
+
+    lines = [line for line in log_path.read_text().splitlines() if line.strip()]
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["dry_run"] is True
+    assert entry["total_lines"] == 2
+    assert entry["removed_count"] == 1
+    assert entry["reason_counts"] == {"Duplicate": 1}

--- a/test_clean_history.py
+++ b/test_clean_history.py
@@ -617,6 +617,54 @@ def test_write_log_appends_across_runs(tmp_path: Path) -> None:
     assert json.loads(lines[1])["total_lines"] == 11
 
 
+def test_write_log_swallows_oserror_and_warns(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An OSError on log write must not crash the run; a stderr warning is emitted."""
+    log_path = tmp_path / "missing-dir" / "cleanup.log"  # parent doesn't exist
+
+    args = argparse.Namespace(no_log=False, dry_run=True)
+    settings = CleaningSettings(similarity_threshold=0.8, rare_threshold=3, remove_rare=False)
+
+    with patch("clean_history.LOG_FILE", log_path):
+        _write_log(args, settings, total_lines=1, removal_reasons={}, cmd_to_lines={})
+
+    captured = capsys.readouterr()
+    assert "warning" in captured.err.lower()
+    assert not log_path.exists()
+
+
+def test_write_log_creates_file_with_0600_mode(tmp_path: Path) -> None:
+    """First-time creation chmods the log to 0o600 to match ~/.zsh_history."""
+    log_path = tmp_path / "cleanup.log"
+
+    args = argparse.Namespace(no_log=False, dry_run=True)
+    settings = CleaningSettings(similarity_threshold=0.8, rare_threshold=3, remove_rare=False)
+
+    with patch("clean_history.LOG_FILE", log_path):
+        _write_log(args, settings, total_lines=1, removal_reasons={}, cmd_to_lines={})
+
+    mode = log_path.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_write_log_does_not_chmod_existing_file(tmp_path: Path) -> None:
+    """Subsequent writes should not chmod — user may have intentionally widened access."""
+    log_path = tmp_path / "cleanup.log"
+    log_path.touch()
+    log_path.chmod(0o644)
+
+    args = argparse.Namespace(no_log=False, dry_run=True)
+    settings = CleaningSettings(similarity_threshold=0.8, rare_threshold=3, remove_rare=False)
+
+    with patch("clean_history.LOG_FILE", log_path):
+        _write_log(args, settings, total_lines=1, removal_reasons={}, cmd_to_lines={})
+
+    mode = log_path.stat().st_mode & 0o777
+    assert mode == 0o644
+
+
 def test_main_writes_log_entry(tmp_path: Path) -> None:
     """main() produces a log entry by default; record reflects what was processed."""
     log_path = tmp_path / "cleanup.log"

--- a/zsh-clean-history.plugin.zsh
+++ b/zsh-clean-history.plugin.zsh
@@ -101,8 +101,18 @@ clean-history-log() {
     while (( $# )); do
         case "$1" in
             --full) full=true; shift ;;
-            -n) n="$2"; shift 2 ;;
-            *) n="$1"; shift ;;
+            -n)
+                if [[ -z "${2:-}" || ! "$2" =~ ^[0-9]+$ ]]; then
+                    echo "clean-history-log: -n requires an integer argument" >&2
+                    return 2
+                fi
+                n="$2"; shift 2 ;;
+            *)
+                if [[ ! "$1" =~ ^[0-9]+$ ]]; then
+                    echo "clean-history-log: invalid argument '$1' (expected integer or --full)" >&2
+                    return 2
+                fi
+                n="$1"; shift ;;
         esac
     done
 
@@ -126,25 +136,34 @@ for line in sys.stdin:
     try:
         e = json.loads(line)
     except ValueError:
-        print(line)
+        print(f"  [unparseable] {line}")
+        continue
+    if not isinstance(e, dict):
+        print(f"  [unexpected json] {line}")
         continue
     mode = "DRY-RUN" if e.get("dry_run") else "APPLIED"
-    ts = e["timestamp"]
-    rm = e["removed_count"]
-    tot = e["total_lines"]
-    sim = e["settings"]["similarity"]
-    rare = e["settings"]["rare_threshold"]
+    ts = e.get("timestamp", "?")
+    rm = e.get("removed_count", "?")
+    tot = e.get("total_lines", "?")
+    settings = e.get("settings") or {}
+    sim = settings.get("similarity", "?")
+    rare = settings.get("rare_threshold", "?")
     print(f"{ts}  {mode}  removed={rm}/{tot}  sim={sim} rare<={rare}")
-    for reason, count in sorted(e.get("reason_counts", {}).items(), key=lambda x: -x[1]):
+    for reason, count in sorted(
+        (e.get("reason_counts") or {}).items(), key=lambda x: -x[1]
+    ):
         print(f"    {count:4}  {reason}")
-    samples = [r for r in e.get("removals", []) if r["reason"] != "Duplicate"][:5]
+    samples = [
+        r for r in (e.get("removals") or [])
+        if isinstance(r, dict) and r.get("reason") != "Duplicate"
+    ][:5]
     if samples:
         print("    samples:")
         for r in samples:
-            cmd = r["command"]
+            cmd = r.get("command", "")
             if len(cmd) > 70:
                 cmd = cmd[:67] + "..."
-            reason = r["reason"]
+            reason = r.get("reason", "?")
             print(f"      [{reason}] {cmd}")
     print()
 '

--- a/zsh-clean-history.plugin.zsh
+++ b/zsh-clean-history.plugin.zsh
@@ -93,6 +93,63 @@ clean-history-stats() {
     python3 "$ZSH_CLEAN_HISTORY_SCRIPT" --dry-run
 }
 
+# Command to inspect recent cleanup runs (default: last 5, --full for full JSON)
+clean-history-log() {
+    local logfile="${HOME}/.zsh_history_cleanup.log"
+    local n=5 full=false
+
+    while (( $# )); do
+        case "$1" in
+            --full) full=true; shift ;;
+            -n) n="$2"; shift 2 ;;
+            *) n="$1"; shift ;;
+        esac
+    done
+
+    if [[ ! -f "$logfile" ]]; then
+        echo "No cleanup log yet at $logfile"
+        echo "Run 'clean-history' or 'clean-history-stats' to generate entries."
+        return 1
+    fi
+
+    if [[ "$full" == true ]]; then
+        tail -n "$n" "$logfile"
+        return
+    fi
+
+    tail -n "$n" "$logfile" | python3 -c '
+import json, sys
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        e = json.loads(line)
+    except ValueError:
+        print(line)
+        continue
+    mode = "DRY-RUN" if e.get("dry_run") else "APPLIED"
+    ts = e["timestamp"]
+    rm = e["removed_count"]
+    tot = e["total_lines"]
+    sim = e["settings"]["similarity"]
+    rare = e["settings"]["rare_threshold"]
+    print(f"{ts}  {mode}  removed={rm}/{tot}  sim={sim} rare<={rare}")
+    for reason, count in sorted(e.get("reason_counts", {}).items(), key=lambda x: -x[1]):
+        print(f"    {count:4}  {reason}")
+    samples = [r for r in e.get("removals", []) if r["reason"] != "Duplicate"][:5]
+    if samples:
+        print("    samples:")
+        for r in samples:
+            cmd = r["command"]
+            if len(cmd) > 70:
+                cmd = cmd[:67] + "..."
+            reason = r["reason"]
+            print(f"      [{reason}] {cmd}")
+    print()
+'
+}
+
 # Auto-clean on shell exit if enabled
 if [[ "$ZSH_CLEAN_HISTORY_AUTO_CLEAN" == "true" ]]; then
     _zsh_clean_history_exit() {


### PR DESCRIPTION
## Motivation

No visibility into what `clean-history` actually removes. With only
stdout summaries, hard to audit false positives, tune similarity
threshold, or improve heuristics over time.

## Implementation information

Append one JSONL record per run to `~/.zsh_history_cleanup.log`
(both dry-run and real). Each record carries timestamp, settings,
totals, reason counts, and per-line removals (idx + reason +
command). JSONL keeps it grep/jq-friendly and append-only safe.

- `LOG_FILE` constant + `_write_log()` in `clean_history.py`
- `--no-log` flag for opt-out
- `clean-history-log [N] [--full]` viewer — pretty summary by
  default, raw JSONL with `--full`
- 4 new tests covering write/skip/append/integration; existing
  `main()` tests pass `--no-log` so they don't pollute home
- README documents schema, viewer, and jq usage

Alternatives discarded:
- Plain text log: harder to analyse trends.
- Always-on stdout dump: too noisy for `auto-clean` on shell exit.

## Supporting documentation

Sample entry:

```json
{"timestamp": "2026-05-08T08:59:35+00:00", "dry_run": true,
 "settings": {"similarity": 0.8, "rare_threshold": 3, "remove_rare": false},
 "total_lines": 858, "removed_count": 84,
 "reason_counts": {"Duplicate": 70, "Failed similar to '...'": 4, ...},
 "removals": [{"line": 56, "reason": "...", "command": "..."}]}
```

> Changelog: feat(log): record cleanup runs to jsonl log