### PR TITLE
feat(cli): add explain subcommand

### DIFF
--- a/src/cleaner.rs
+++ b/src/cleaner.rs
@@ -41,7 +41,10 @@ pub fn identify_removals(parsed: &ParsedHistory, settings: &CleaningSettings) ->
     out
 }
 
-fn dedup_keep_newest(parsed: &ParsedHistory, removals: &mut HashMap<usize, (String, Option<String>)>) {
+fn dedup_keep_newest(
+    parsed: &ParsedHistory,
+    removals: &mut HashMap<usize, (String, Option<String>)>,
+) {
     for (cmd, indices) in &parsed.cmd_to_lines {
         if indices.len() <= 1 {
             continue;

--- a/src/cleaner.rs
+++ b/src/cleaner.rs
@@ -11,10 +11,11 @@ pub struct Removal {
     pub line: usize,
     pub reason: String,
     pub command: String,
+    pub candidate: Option<String>,
 }
 
 pub fn identify_removals(parsed: &ParsedHistory, settings: &CleaningSettings) -> Vec<Removal> {
-    let mut removals: HashMap<usize, String> = HashMap::new();
+    let mut removals: HashMap<usize, (String, Option<String>)> = HashMap::new();
     dedup_keep_newest(parsed, &mut removals);
     failed_similar_to_successful(parsed, settings, &mut removals);
     if settings.remove_rare {
@@ -22,7 +23,7 @@ pub fn identify_removals(parsed: &ParsedHistory, settings: &CleaningSettings) ->
     }
     let mut out: Vec<Removal> = removals
         .into_iter()
-        .map(|(idx, reason)| {
+        .map(|(idx, (reason, candidate))| {
             let command = parsed
                 .entries
                 .get(idx)
@@ -32,6 +33,7 @@ pub fn identify_removals(parsed: &ParsedHistory, settings: &CleaningSettings) ->
                 line: idx,
                 reason,
                 command,
+                candidate,
             }
         })
         .collect();
@@ -39,7 +41,7 @@ pub fn identify_removals(parsed: &ParsedHistory, settings: &CleaningSettings) ->
     out
 }
 
-fn dedup_keep_newest(parsed: &ParsedHistory, removals: &mut HashMap<usize, String>) {
+fn dedup_keep_newest(parsed: &ParsedHistory, removals: &mut HashMap<usize, (String, Option<String>)>) {
     for (cmd, indices) in &parsed.cmd_to_lines {
         if indices.len() <= 1 {
             continue;
@@ -49,7 +51,7 @@ fn dedup_keep_newest(parsed: &ParsedHistory, removals: &mut HashMap<usize, Strin
             if idx != keep {
                 removals
                     .entry(idx)
-                    .or_insert_with(|| "Duplicate".to_string());
+                    .or_insert_with(|| ("Duplicate".to_string(), None));
             }
         }
     }
@@ -58,7 +60,7 @@ fn dedup_keep_newest(parsed: &ParsedHistory, removals: &mut HashMap<usize, Strin
 fn failed_similar_to_successful(
     parsed: &ParsedHistory,
     settings: &CleaningSettings,
-    removals: &mut HashMap<usize, String>,
+    removals: &mut HashMap<usize, (String, Option<String>)>,
 ) {
     let by_base = group_by_base_strings(parsed.successful_counts.keys());
     for (failed_cmd, &fail_count) in &parsed.failed_counts {
@@ -67,7 +69,7 @@ fn failed_similar_to_successful(
             Some(v) => v,
             None => continue,
         };
-        let mut chosen: Option<String> = None;
+        let mut chosen: Option<(String, Option<String>)> = None;
         for &success_cmd in candidates {
             if success_cmd == failed_cmd {
                 continue;
@@ -82,19 +84,25 @@ fn failed_similar_to_successful(
             }
             if success_cmd.starts_with(failed_cmd.as_str()) && success_cmd.len() > failed_cmd.len()
             {
-                chosen = Some(format!("Failed prefix of '{success_cmd}'"));
+                chosen = Some((
+                    format!("Failed prefix of '{success_cmd}'"),
+                    Some(success_cmd.to_string()),
+                ));
                 break;
             }
             let sim = ratio(failed_cmd, success_cmd);
             if (settings.similarity_threshold..1.0).contains(&sim) {
-                chosen = Some(format!("Failed similar to '{success_cmd}'"));
+                chosen = Some((
+                    format!("Failed similar to '{success_cmd}'"),
+                    Some(success_cmd.to_string()),
+                ));
                 break;
             }
         }
-        if let Some(reason) = chosen {
+        if let Some(entry) = chosen {
             if let Some(indices) = parsed.cmd_to_lines.get(failed_cmd) {
                 for &idx in indices {
-                    removals.entry(idx).or_insert_with(|| reason.clone());
+                    removals.entry(idx).or_insert_with(|| entry.clone());
                 }
             }
         }
@@ -104,7 +112,7 @@ fn failed_similar_to_successful(
 fn rare_variants(
     parsed: &ParsedHistory,
     settings: &CleaningSettings,
-    removals: &mut HashMap<usize, String>,
+    removals: &mut HashMap<usize, (String, Option<String>)>,
 ) {
     let mut all_counts: HashMap<&str, usize> = HashMap::new();
     for (cmd, &n) in &parsed.successful_counts {
@@ -133,9 +141,12 @@ fn rare_variants(
             let sim = ratio(rare_cmd, common_cmd);
             if sim >= settings.similarity_threshold {
                 if let Some(indices) = parsed.cmd_to_lines.get(*rare_cmd) {
-                    let reason = format!("Rare variant of '{common_cmd}'");
+                    let entry = (
+                        format!("Rare variant of '{common_cmd}'"),
+                        Some(common_cmd.to_string()),
+                    );
                     for &idx in indices {
-                        removals.entry(idx).or_insert_with(|| reason.clone());
+                        removals.entry(idx).or_insert_with(|| entry.clone());
                     }
                 }
                 break;

--- a/src/log.rs
+++ b/src/log.rs
@@ -100,6 +100,7 @@ mod tests {
             line: 3,
             reason: "Failed similar to 'git status'".into(),
             command: "git statsu".into(),
+            candidate: Some("git status".into()),
         }];
         write_log_entry(&log, &settings, true, 42, &removals).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -41,6 +41,7 @@ struct Cli {
 enum Cmd {
     Undo,
     RecordExit { timestamp: String, exit_code: i32 },
+    Explain { command: String },
 }
 
 fn main() -> Result<()> {
@@ -53,6 +54,7 @@ fn main() -> Result<()> {
             timestamp,
             exit_code,
         }) => zsh_clean_history::exits::append_exit(&paths.exits, &timestamp, exit_code),
+        Some(Cmd::Explain { ref command }) => explain(command, &cli, &paths),
         None => run_cleanup(&cli, &paths),
     }
 }
@@ -127,6 +129,56 @@ fn run_cleanup(cli: &Cli, paths: &Paths) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn explain(command: &str, cli: &Cli, paths: &Paths) -> Result<()> {
+    let settings = CleaningSettings {
+        similarity_threshold: cli.similarity,
+        rare_threshold: cli.rare_threshold,
+        remove_rare: cli.remove_rare,
+    };
+
+    let exit_codes = load_exit_codes(&paths.exits)?;
+    let parsed = parse_history_file(&paths.history, &exit_codes)?;
+    let removals = identify_removals(&parsed, &settings);
+    let removal_map: HashMap<usize, &Removal> =
+        removals.iter().map(|r| (r.line, r)).collect();
+
+    let success_count = parsed.successful_counts.get(command).copied().unwrap_or(0);
+    let fail_count = parsed.failed_counts.get(command).copied().unwrap_or(0);
+    let indices = parsed.cmd_to_lines.get(command).cloned().unwrap_or_default();
+
+    if indices.is_empty() {
+        println!("command not found in history: {command}");
+        return Ok(());
+    }
+
+    println!("command:  {command}");
+    println!("runs:     success={success_count} failed={fail_count}");
+    println!("entries:  {}", indices.len());
+
+    for &idx in &indices {
+        print!("  [{idx}] ");
+        if let Some(removal) = removal_map.get(&idx) {
+            print!("REMOVE  reason: {}", removal.reason);
+            if let Some(candidate) = extract_candidate(&removal.reason) {
+                let sim = zsh_clean_history::similarity::ratio(command, &candidate);
+                print!("  similarity: {sim:.2}");
+            }
+        } else {
+            print!("KEEP");
+        }
+        println!();
+    }
+
+    Ok(())
+}
+
+fn extract_candidate(reason: &str) -> Option<String> {
+    let start = reason.find('\'')?;
+    let rest = &reason[start + 1..];
+    let end = rest.rfind('\'')?;
+    Some(rest[..end].to_string())
 }
 
 fn write_history_atomically(

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,12 +59,16 @@ fn main() -> Result<()> {
     }
 }
 
-fn run_cleanup(cli: &Cli, paths: &Paths) -> Result<()> {
-    let settings = CleaningSettings {
+fn settings_from_cli(cli: &Cli) -> CleaningSettings {
+    CleaningSettings {
         similarity_threshold: cli.similarity,
         rare_threshold: cli.rare_threshold,
         remove_rare: cli.remove_rare,
-    };
+    }
+}
+
+fn run_cleanup(cli: &Cli, paths: &Paths) -> Result<()> {
+    let settings = settings_from_cli(cli);
 
     let _lock = LockedHistory::acquire(&paths.lock_file())?;
 
@@ -132,11 +136,7 @@ fn run_cleanup(cli: &Cli, paths: &Paths) -> Result<()> {
 }
 
 fn explain(command: &str, cli: &Cli, paths: &Paths) -> Result<()> {
-    let settings = CleaningSettings {
-        similarity_threshold: cli.similarity,
-        rare_threshold: cli.rare_threshold,
-        remove_rare: cli.remove_rare,
-    };
+    let settings = settings_from_cli(cli);
 
     let exit_codes = load_exit_codes(&paths.exits)?;
     let parsed = parse_history_file(&paths.history, &exit_codes)?;
@@ -149,8 +149,7 @@ fn explain(command: &str, cli: &Cli, paths: &Paths) -> Result<()> {
     let indices = parsed.cmd_to_lines.get(command).cloned().unwrap_or_default();
 
     if indices.is_empty() {
-        println!("command not found in history: {command}");
-        return Ok(());
+        anyhow::bail!("command not found in history: {command}");
     }
 
     println!("command:  {command}");
@@ -161,8 +160,8 @@ fn explain(command: &str, cli: &Cli, paths: &Paths) -> Result<()> {
         print!("  [{idx}] ");
         if let Some(removal) = removal_map.get(&idx) {
             print!("REMOVE  reason: {}", removal.reason);
-            if let Some(candidate) = extract_candidate(&removal.reason) {
-                let sim = zsh_clean_history::similarity::ratio(command, &candidate);
+            if let Some(ref candidate) = removal.candidate {
+                let sim = zsh_clean_history::similarity::ratio(command, candidate);
                 print!("  similarity: {sim:.2}");
             }
         } else {
@@ -172,13 +171,6 @@ fn explain(command: &str, cli: &Cli, paths: &Paths) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn extract_candidate(reason: &str) -> Option<String> {
-    let start = reason.find('\'')?;
-    let rest = &reason[start + 1..];
-    let end = rest.rfind('\'')?;
-    Some(rest[..end].to_string())
 }
 
 fn write_history_atomically(

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,12 +141,15 @@ fn explain(command: &str, cli: &Cli, paths: &Paths) -> Result<()> {
     let exit_codes = load_exit_codes(&paths.exits)?;
     let parsed = parse_history_file(&paths.history, &exit_codes)?;
     let removals = identify_removals(&parsed, &settings);
-    let removal_map: HashMap<usize, &Removal> =
-        removals.iter().map(|r| (r.line, r)).collect();
+    let removal_map: HashMap<usize, &Removal> = removals.iter().map(|r| (r.line, r)).collect();
 
     let success_count = parsed.successful_counts.get(command).copied().unwrap_or(0);
     let fail_count = parsed.failed_counts.get(command).copied().unwrap_or(0);
-    let indices = parsed.cmd_to_lines.get(command).cloned().unwrap_or_default();
+    let indices = parsed
+        .cmd_to_lines
+        .get(command)
+        .cloned()
+        .unwrap_or_default();
 
     if indices.is_empty() {
         anyhow::bail!("command not found in history: {command}");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 use assert_cmd::Command;
+use predicates::str::contains;
 use tempfile::tempdir;
 
 fn run(home: &std::path::Path, args: &[&str]) -> assert_cmd::assert::Assert {
@@ -97,6 +98,40 @@ fn multiline_entry_round_trips_unchanged() {
         after.contains(": 1:0;echo foo \\\n  bar"),
         "multi-line entry corrupted: {after:?}"
     );
+}
+
+#[test]
+fn explain_shows_removal_reason_for_removed_entry() {
+    let dir = tempdir().unwrap();
+    let home = dir.path();
+    fs::write(
+        home.join(".zsh_history"),
+        ": 1:0;git statsu\n: 2:0;git status\n: 3:0;git status\n",
+    )
+    .unwrap();
+    fs::write(home.join(".zsh_history_exits"), "1:127\n2:0\n3:0\n").unwrap();
+
+    run(home, &["explain", "git statsu"])
+        .success()
+        .stdout(contains("REMOVE"))
+        .stdout(contains("Failed similar to"))
+        .stdout(contains("similarity:"));
+}
+
+#[test]
+fn explain_shows_keep_for_non_removed_entry() {
+    let dir = tempdir().unwrap();
+    let home = dir.path();
+    fs::write(
+        home.join(".zsh_history"),
+        ": 1:0;git statsu\n: 2:0;git status\n: 3:0;git status\n",
+    )
+    .unwrap();
+    fs::write(home.join(".zsh_history_exits"), "1:127\n2:0\n3:0\n").unwrap();
+
+    run(home, &["explain", "git status"])
+        .success()
+        .stdout(contains("KEEP"));
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Users had no way to inspect why the cleaner would keep or remove a specific command from history. The `explain` subcommand gives a per-entry breakdown — success/fail counts, which entries would be removed and why, and similarity scores for duplicate candidates.

Closes https://github.com/Automaat/zsh-clean-history/issues/27

## Implementation information

- Added `Explain { command: String }` variant to the `Cmd` enum
- Extracted `settings_from_cli` helper to avoid repeating `CleaningSettings` construction in both `run_cleanup` and `explain`
- `explain` reuses existing `identify_removals` + `parse_history_file` internals; builds a `HashMap<usize, &Removal>` for O(1) lookup per entry
- Output format: command stats header followed by one line per history entry tagged `KEEP` or `REMOVE reason: …` with optional similarity score
- Added integration tests in `tests/cli.rs` covering the explain path