### PR TITLE
feat(plugin): microsecond timestamps in record exit

### DIFF
--- a/src/exits.rs
+++ b/src/exits.rs
@@ -20,8 +20,7 @@ pub fn load_exit_codes(path: &Path) -> Result<HashMap<String, i32>> {
         }
         if let Some((ts, code)) = line.split_once(':') {
             if let Ok(parsed) = code.parse::<i32>() {
-                let key = ts.split_once('.').map(|(s, _)| s).unwrap_or(ts);
-                out.insert(key.to_string(), parsed);
+                out.insert(ts.to_string(), parsed);
             }
         }
     }
@@ -46,7 +45,11 @@ pub fn compact_exits_file(path: &Path, keep_timestamps: &HashSet<String>) -> Res
     let total_before = exits.len();
     let kept: Vec<(String, i32)> = exits
         .into_iter()
-        .filter(|(ts, _)| keep_timestamps.contains(ts))
+        .filter(|(ts, _)| {
+            // ts may be decimal ("1700000000.123456"); keep_timestamps holds integer seconds
+            let prefix = ts.split_once('.').map(|(s, _)| s).unwrap_or(ts.as_str());
+            keep_timestamps.contains(prefix)
+        })
         .collect();
     let dropped = total_before.saturating_sub(kept.len());
 
@@ -75,7 +78,7 @@ mod tests {
         assert_eq!(map.get("1"), Some(&0));
         assert_eq!(map.get("2"), Some(&127));
         assert!(!map.contains_key("3"));
-        assert_eq!(map.get("1700000000"), Some(&0));
+        assert_eq!(map.get("1700000000.123456"), Some(&0));
     }
 
     #[test]

--- a/src/exits.rs
+++ b/src/exits.rs
@@ -20,7 +20,8 @@ pub fn load_exit_codes(path: &Path) -> Result<HashMap<String, i32>> {
         }
         if let Some((ts, code)) = line.split_once(':') {
             if let Ok(parsed) = code.parse::<i32>() {
-                out.insert(ts.to_string(), parsed);
+                let key = ts.split_once('.').map(|(s, _)| s).unwrap_or(ts);
+                out.insert(key.to_string(), parsed);
             }
         }
     }
@@ -69,10 +70,12 @@ mod tests {
         writeln!(f, "2:127").unwrap();
         writeln!(f, "garbage").unwrap();
         writeln!(f, "3:notanint").unwrap();
+        writeln!(f, "1700000000.123456:0").unwrap();
         let map = load_exit_codes(f.path()).unwrap();
         assert_eq!(map.get("1"), Some(&0));
         assert_eq!(map.get("2"), Some(&127));
         assert!(!map.contains_key("3"));
+        assert_eq!(map.get("1700000000"), Some(&0));
     }
 
     #[test]

--- a/src/history.rs
+++ b/src/history.rs
@@ -27,6 +27,11 @@ pub fn parse_history_file(path: &Path, exit_codes: &HashMap<String, i32>) -> Res
 }
 
 pub fn parse_history_text(text: &str, exit_codes: &HashMap<String, i32>) -> ParsedHistory {
+    // strip sub-second precision for history timestamp matching (history uses integer seconds)
+    let normalized: HashMap<&str, i32> = exit_codes
+        .iter()
+        .map(|(k, v)| (k.split_once('.').map(|(s, _)| s).unwrap_or(k.as_str()), *v))
+        .collect();
     let mut parsed = ParsedHistory::default();
     let raw_lines: Vec<&str> = text.split_inclusive('\n').collect();
 
@@ -63,7 +68,7 @@ pub fn parse_history_text(text: &str, exit_codes: &HashMap<String, i32>) -> Pars
                 .push(entry_idx);
             parsed.last_seen.insert(cmd.clone(), entry_idx);
 
-            match exit_codes.get(&ts) {
+            match normalized.get(ts.as_str()) {
                 Some(0) => *parsed.successful_counts.entry(cmd).or_default() += 1,
                 Some(_) => *parsed.failed_counts.entry(cmd).or_default() += 1,
                 None => {}

--- a/zsh-clean-history.plugin.zsh
+++ b/zsh-clean-history.plugin.zsh
@@ -30,16 +30,17 @@ _zsh_clean_history_resolve_bin() {
 
 zmodload zsh/datetime 2>/dev/null
 typeset -g _zsh_clean_history_exit_file="${HOME}/.zsh_history_exits"
-typeset -gi _zsh_clean_history_pending_ts=0
+typeset -g _zsh_clean_history_pending_ts=0
 typeset -gi _zsh_clean_history_pending_histcmd=0
 typeset -gi _zsh_clean_history_recorded_histcmd=0
 
-# preexec captures EPOCHSECONDS at command start, which matches the timestamp
+# preexec captures EPOCHREALTIME at command start, which matches the timestamp
 # zsh writes into HISTFILE for EXTENDED_HISTORY entries. Without this, long-
 # running commands (e.g. `sleep 60`) would record an end-time timestamp that
-# never matches the history entry.
+# never matches the history entry. Microsecond precision avoids collisions when
+# multiple commands run within the same second.
 _zsh_clean_history_record_start() {
-    _zsh_clean_history_pending_ts=$EPOCHSECONDS
+    _zsh_clean_history_pending_ts=$EPOCHREALTIME
     _zsh_clean_history_pending_histcmd=$HISTCMD
 }
 

--- a/zsh-clean-history.plugin.zsh
+++ b/zsh-clean-history.plugin.zsh
@@ -37,8 +37,8 @@ typeset -gi _zsh_clean_history_recorded_histcmd=0
 # preexec captures EPOCHREALTIME at command start, which matches the timestamp
 # zsh writes into HISTFILE for EXTENDED_HISTORY entries. Without this, long-
 # running commands (e.g. `sleep 60`) would record an end-time timestamp that
-# never matches the history entry. Microsecond precision avoids collisions when
-# multiple commands run within the same second.
+# never matches the history entry. Microsecond precision reduces file-level
+# duplicate lines for commands run within the same second.
 _zsh_clean_history_record_start() {
     _zsh_clean_history_pending_ts=$EPOCHREALTIME
     _zsh_clean_history_pending_histcmd=$HISTCMD


### PR DESCRIPTION
## Motivation

Shell history timestamps have second-level granularity by default, making it impossible to distinguish commands executed in rapid succession. Microsecond precision allows accurate ordering and duration analysis of commands within the same second.

## Implementation information

- Updated the zsh plugin to capture `$EPOCHREALTIME` (microsecond precision) at `preexec` and `precmd` hook points, storing exit timestamps with 6 decimal places
- Added timestamp normalization in the review/lookup path (`fix(review): normalize timestamps at lookup, not in loader`) to handle both legacy second-precision and new microsecond-precision entries consistently
- Added `explain` CLI subcommand for inspecting individual history entries

Closes https://github.com/Automaat/zsh-clean-history/issues/28