### PR TITLE
feat(plugin): async cleanup on shell exit with failure logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The plugin auto-finds the binary on `PATH`, or falls back to `target/release/zsh
 ## Configuration
 
 ```bash
-# Auto-clean on shell exit (default: false)
+# Auto-clean on shell exit (default: false); runs in background, non-blocking
+# Failures are logged to ~/.zsh_history_cleanup.log
 ZSH_CLEAN_HISTORY_AUTO_CLEAN=true
 
 # Similarity threshold 0..1 (default: 0.8)

--- a/zsh-clean-history.plugin.zsh
+++ b/zsh-clean-history.plugin.zsh
@@ -150,6 +150,6 @@ clean-history-log() {
 }
 
 if [[ "$ZSH_CLEAN_HISTORY_AUTO_CLEAN" == "true" ]]; then
-    _zsh_clean_history_exit() { clean-history --quiet; }
+    _zsh_clean_history_exit() { clean-history --quiet </dev/null >/dev/null 2>&1 &! }
     add-zsh-hook zshexit _zsh_clean_history_exit
 fi

--- a/zsh-clean-history.plugin.zsh
+++ b/zsh-clean-history.plugin.zsh
@@ -150,6 +150,18 @@ clean-history-log() {
 }
 
 if [[ "$ZSH_CLEAN_HISTORY_AUTO_CLEAN" == "true" ]]; then
-    _zsh_clean_history_exit() { clean-history --quiet </dev/null >/dev/null 2>&1 &! }
+    _zsh_clean_history_exit() {
+        {
+            local out rc
+            out=$(clean-history --quiet 2>&1)
+            rc=$?
+            if (( rc != 0 )); then
+                local ts
+                strftime -s ts '%Y-%m-%dT%H:%M:%SZ' $EPOCHSECONDS
+                printf '[%s] ERROR exit=%d %s\n' "$ts" "$rc" "$out" \
+                    >> "${HOME}/.zsh_history_cleanup.log"
+            fi
+        } </dev/null &!
+    }
     add-zsh-hook zshexit _zsh_clean_history_exit
 fi


### PR DESCRIPTION
## Motivation

Shell exit was blocked by the cleanup process duration. Users experienced a noticeable delay before the shell prompt returned after `exit` or closing the terminal. Silent failures also made it impossible to diagnose cleanup errors.

Closes https://github.com/Automaat/zsh-clean-history/issues/29

## Implementation information

- Background and disown the cleanup process (`&!`) so the shell exits immediately without waiting for cleanup to finish
- Capture stderr and exit code in the background block; on non-zero exit, append a timestamped `ERROR` line to `~/.zsh_history_cleanup.log`
- Update README to document non-blocking behavior and the failure log path