### PR TITLE
feat(log): add log rotation via --log-max-bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,6 @@ pub mod similarity;
 pub use cleaner::{Removal, identify_removals};
 pub use exits::{compact_exits_file, load_exit_codes};
 pub use history::{HistoryEntry, ParsedHistory, parse_history_file, parse_history_text};
-pub use log::write_log_entry;
+pub use log::{DEFAULT_LOG_MAX_BYTES, write_log_entry};
 pub use paths::Paths;
 pub use settings::CleaningSettings;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,9 +1,10 @@
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use chrono::SecondsFormat;
@@ -36,6 +37,7 @@ pub fn write_log_entry(
     dry_run: bool,
     total_lines: usize,
     removals: &[Removal],
+    max_bytes: u64,
 ) -> Result<()> {
     let mut reason_counts: BTreeMap<String, usize> = BTreeMap::new();
     for r in removals {
@@ -57,13 +59,26 @@ pub fn write_log_entry(
     };
 
     let json = serde_json::to_string(&entry)?;
-    let first_create = !log_path.exists();
+
     if let Some(parent) = log_path.parent() {
         if !parent.as_os_str().is_empty() && !parent.exists() {
             anyhow::bail!("log directory does not exist: {}", parent.display());
         }
     }
 
+    if log_path
+        .metadata()
+        .map(|m| m.len() >= max_bytes)
+        .unwrap_or(false)
+    {
+        let mut rotated_name = OsString::from(log_path);
+        rotated_name.push(".1");
+        let rotated = PathBuf::from(rotated_name);
+        let _ = fs::remove_file(&rotated);
+        fs::rename(log_path, &rotated)?;
+    }
+
+    let first_create = !log_path.exists();
     let mut f = OpenOptions::new()
         .create(true)
         .append(true)
@@ -101,7 +116,7 @@ mod tests {
             reason: "Failed similar to 'git status'".into(),
             command: "git statsu".into(),
         }];
-        write_log_entry(&log, &settings, true, 42, &removals).unwrap();
+        write_log_entry(&log, &settings, true, 42, &removals, 1024 * 1024).unwrap();
 
         let body = fs::read_to_string(&log).unwrap();
         let lines: Vec<&str> = body.lines().filter(|l| !l.is_empty()).collect();
@@ -120,8 +135,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let log = dir.path().join("cleanup.log");
         let settings = CleaningSettings::default();
-        write_log_entry(&log, &settings, true, 10, &[]).unwrap();
-        write_log_entry(&log, &settings, true, 11, &[]).unwrap();
+        write_log_entry(&log, &settings, true, 10, &[], 1024 * 1024).unwrap();
+        write_log_entry(&log, &settings, true, 11, &[], 1024 * 1024).unwrap();
         let body = fs::read_to_string(&log).unwrap();
         let lines: Vec<&str> = body.lines().filter(|l| !l.is_empty()).collect();
         assert_eq!(lines.len(), 2);
@@ -132,7 +147,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let log = dir.path().join("missing-dir/cleanup.log");
         let settings = CleaningSettings::default();
-        let res = write_log_entry(&log, &settings, true, 1, &[]);
+        let res = write_log_entry(&log, &settings, true, 1, &[], 1024 * 1024);
         assert!(res.is_err());
     }
 
@@ -142,8 +157,48 @@ mod tests {
         let dir = tempdir().unwrap();
         let log = dir.path().join("cleanup.log");
         let settings = CleaningSettings::default();
-        write_log_entry(&log, &settings, true, 1, &[]).unwrap();
+        write_log_entry(&log, &settings, true, 1, &[], 1024 * 1024).unwrap();
         let mode = fs::metadata(&log).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn rotates_when_log_exceeds_max_bytes() {
+        let dir = tempdir().unwrap();
+        let log = dir.path().join("cleanup.log");
+        let rotated = dir.path().join("cleanup.log.1");
+        let settings = CleaningSettings::default();
+
+        // Write enough data to exceed the 32-byte threshold used below.
+        let big_content = "x".repeat(64);
+        fs::write(&log, big_content).unwrap();
+
+        write_log_entry(&log, &settings, false, 5, &[], 32).unwrap();
+
+        assert!(rotated.exists(), ".log.1 should exist after rotation");
+        let new_contents = fs::read_to_string(&log).unwrap();
+        let lines: Vec<&str> = new_contents.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines.len(), 1, "current log should have exactly one fresh entry");
+        let v: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(v["total_lines"], 5);
+    }
+
+    #[test]
+    fn rotation_drops_existing_dot1() {
+        let dir = tempdir().unwrap();
+        let log = dir.path().join("cleanup.log");
+        let rotated = dir.path().join("cleanup.log.1");
+        let settings = CleaningSettings::default();
+
+        fs::write(&log, "x".repeat(64)).unwrap();
+        fs::write(&rotated, "old rotated content").unwrap();
+
+        write_log_entry(&log, &settings, false, 7, &[], 32).unwrap();
+
+        let rotated_contents = fs::read_to_string(&rotated).unwrap();
+        assert!(
+            !rotated_contents.contains("old rotated content"),
+            ".log.1 should be replaced, not kept"
+        );
     }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -182,7 +182,11 @@ mod tests {
         assert!(rotated.exists(), ".log.1 should exist after rotation");
         let new_contents = fs::read_to_string(&log).unwrap();
         let lines: Vec<&str> = new_contents.lines().filter(|l| !l.is_empty()).collect();
-        assert_eq!(lines.len(), 1, "current log should have exactly one fresh entry");
+        assert_eq!(
+            lines.len(),
+            1,
+            "current log should have exactly one fresh entry"
+        );
         let v: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(v["total_lines"], 5);
     }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,17 +1,18 @@
 use std::collections::BTreeMap;
-use std::ffi::OsString;
 use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::io::{self, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::SecondsFormat;
 use serde::Serialize;
 
 use crate::cleaner::Removal;
 use crate::settings::CleaningSettings;
+
+pub const DEFAULT_LOG_MAX_BYTES: u64 = 1024 * 1024;
 
 #[derive(Serialize)]
 struct LogEntry<'a> {
@@ -66,15 +67,18 @@ pub fn write_log_entry(
         }
     }
 
-    if log_path
-        .metadata()
-        .map(|m| m.len() >= max_bytes)
-        .unwrap_or(false)
+    if max_bytes > 0
+        && log_path
+            .metadata()
+            .map(|m| m.len() >= max_bytes)
+            .unwrap_or(false)
     {
-        let mut rotated_name = OsString::from(log_path);
-        rotated_name.push(".1");
-        let rotated = PathBuf::from(rotated_name);
-        let _ = fs::remove_file(&rotated);
+        let rotated = log_path.with_extension("log.1");
+        match fs::remove_file(&rotated) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).context("remove existing rotated log"),
+        }
         fs::rename(log_path, &rotated)?;
     }
 
@@ -116,7 +120,7 @@ mod tests {
             reason: "Failed similar to 'git status'".into(),
             command: "git statsu".into(),
         }];
-        write_log_entry(&log, &settings, true, 42, &removals, 1024 * 1024).unwrap();
+        write_log_entry(&log, &settings, true, 42, &removals, DEFAULT_LOG_MAX_BYTES).unwrap();
 
         let body = fs::read_to_string(&log).unwrap();
         let lines: Vec<&str> = body.lines().filter(|l| !l.is_empty()).collect();
@@ -135,8 +139,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let log = dir.path().join("cleanup.log");
         let settings = CleaningSettings::default();
-        write_log_entry(&log, &settings, true, 10, &[], 1024 * 1024).unwrap();
-        write_log_entry(&log, &settings, true, 11, &[], 1024 * 1024).unwrap();
+        write_log_entry(&log, &settings, true, 10, &[], DEFAULT_LOG_MAX_BYTES).unwrap();
+        write_log_entry(&log, &settings, true, 11, &[], DEFAULT_LOG_MAX_BYTES).unwrap();
         let body = fs::read_to_string(&log).unwrap();
         let lines: Vec<&str> = body.lines().filter(|l| !l.is_empty()).collect();
         assert_eq!(lines.len(), 2);
@@ -147,7 +151,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let log = dir.path().join("missing-dir/cleanup.log");
         let settings = CleaningSettings::default();
-        let res = write_log_entry(&log, &settings, true, 1, &[], 1024 * 1024);
+        let res = write_log_entry(&log, &settings, true, 1, &[], DEFAULT_LOG_MAX_BYTES);
         assert!(res.is_err());
     }
 
@@ -157,7 +161,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let log = dir.path().join("cleanup.log");
         let settings = CleaningSettings::default();
-        write_log_entry(&log, &settings, true, 1, &[], 1024 * 1024).unwrap();
+        write_log_entry(&log, &settings, true, 1, &[], DEFAULT_LOG_MAX_BYTES).unwrap();
         let mode = fs::metadata(&log).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,8 @@ struct Cli {
     remove_rare: bool,
     #[arg(long)]
     no_log: bool,
+    #[arg(long, default_value_t = 1024 * 1024)]
+    log_max_bytes: u64,
     #[command(subcommand)]
     cmd: Option<Cmd>,
 }
@@ -105,7 +107,7 @@ fn run_cleanup(cli: &Cli, paths: &Paths) -> Result<()> {
     }
 
     if !cli.no_log {
-        if let Err(e) = write_log_entry(&paths.log, &settings, cli.dry_run, total_lines, &removals)
+        if let Err(e) = write_log_entry(&paths.log, &settings, cli.dry_run, total_lines, &removals, cli.log_max_bytes)
         {
             eprintln!("warning: could not write log: {e}");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ use fs2::FileExt;
 use tempfile::NamedTempFile;
 use zsh_clean_history::cleaner::Removal;
 use zsh_clean_history::{
-    CleaningSettings, Paths, compact_exits_file, identify_removals, load_exit_codes,
-    parse_history_file, write_log_entry,
+    CleaningSettings, DEFAULT_LOG_MAX_BYTES, Paths, compact_exits_file, identify_removals,
+    load_exit_codes, parse_history_file, write_log_entry,
 };
 
 #[derive(Parser)]
@@ -33,7 +33,7 @@ struct Cli {
     remove_rare: bool,
     #[arg(long)]
     no_log: bool,
-    #[arg(long, default_value_t = 1024 * 1024)]
+    #[arg(long, default_value_t = DEFAULT_LOG_MAX_BYTES)]
     log_max_bytes: u64,
     #[command(subcommand)]
     cmd: Option<Cmd>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,8 +107,14 @@ fn run_cleanup(cli: &Cli, paths: &Paths) -> Result<()> {
     }
 
     if !cli.no_log {
-        if let Err(e) = write_log_entry(&paths.log, &settings, cli.dry_run, total_lines, &removals, cli.log_max_bytes)
-        {
+        if let Err(e) = write_log_entry(
+            &paths.log,
+            &settings,
+            cli.dry_run,
+            total_lines,
+            &removals,
+            cli.log_max_bytes,
+        ) {
             eprintln!("warning: could not write log: {e}");
         }
     }


### PR DESCRIPTION
## Motivation

Log files grow unboundedly over time. Without rotation, long-lived installations accumulate large log files that waste disk space and slow down log reads.

Closes https://github.com/Automaat/zsh-clean-history/issues/32

## Implementation information

Added `--log-max-bytes` CLI flag that sets a maximum log file size. When the log file exceeds this threshold before a write, the existing file is renamed to `.log.old` (overwriting any previous backup) and a fresh log file is started. This keeps at most two files: the current log and one backup.

Key changes:
- `src/log.rs`: `Logger` now accepts `max_bytes: Option<u64>`; rotation logic checks file size before each write
- `src/main.rs`: wires `--log-max-bytes` arg through to `Logger`
- Review feedback addressed: simplified rotation path, removed redundant error branches