### PR TITLE
feat(dist): add shell completions and manpage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +196,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -538,6 +557,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rustix"
@@ -977,6 +1002,8 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "fs2",
  "predicates",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ strsim = "0.11"
 tempfile = "3"
 
 [build-dependencies]
-clap = "4"
+clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 clap_mangen = "0.2"
 
@@ -51,4 +51,11 @@ cargo-dist-version = "0.28.0"
 ci = ["github"]
 installers = ["shell", "homebrew"]
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
-include = ["completions/_zsh-clean-history"]
+include = [
+    "completions/_zsh-clean-history",
+    "completions/zsh-clean-history.bash",
+    "completions/zsh-clean-history.fish",
+    "completions/zsh-clean-history.elv",
+    "completions/_zsh-clean-history.ps1",
+    "man/zsh-clean-history.1",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ regex = ">=1.5.5, <2"
 strsim = "0.11"
 tempfile = "3"
 
+[build-dependencies]
+clap = "4"
+clap_complete = "4"
+clap_mangen = "0.2"
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
@@ -46,3 +51,4 @@ cargo-dist-version = "0.28.0"
 ci = ["github"]
 installers = ["shell", "homebrew"]
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
+include = ["completions/_zsh-clean-history"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,96 @@
+use std::{env, fs, io};
+
+fn main() -> io::Result<()> {
+    let out = env::var_os("OUT_DIR").unwrap();
+    let comp_dir = std::path::Path::new(&out).join("completions");
+    let man_dir = std::path::Path::new(&out).join("man");
+    fs::create_dir_all(&comp_dir)?;
+    fs::create_dir_all(&man_dir)?;
+
+    let shells = [
+        clap_complete::Shell::Bash,
+        clap_complete::Shell::Zsh,
+        clap_complete::Shell::Fish,
+        clap_complete::Shell::Elvish,
+        clap_complete::Shell::PowerShell,
+    ];
+    let mut cmd = cli();
+    for shell in shells {
+        clap_complete::generate_to(shell, &mut cmd, "zsh-clean-history", &comp_dir)?;
+    }
+
+    let man = clap_mangen::Man::new(cli());
+    let mut buf = Vec::<u8>::new();
+    man.render(&mut buf)?;
+    fs::write(man_dir.join("zsh-clean-history.1"), buf)?;
+
+    Ok(())
+}
+
+fn cli() -> clap::Command {
+    clap::Command::new("zsh-clean-history")
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("Smart zsh history cleaner - removes typos and failed commands")
+        .arg(
+            clap::Arg::new("similarity")
+                .long("similarity")
+                .default_value("0.8")
+                .value_parser(clap::value_parser!(f64))
+                .help("Similarity threshold (0.0–1.0) for deduplication"),
+        )
+        .arg(
+            clap::Arg::new("rare-threshold")
+                .long("rare-threshold")
+                .default_value("3")
+                .value_parser(clap::value_parser!(usize))
+                .help("Commands run fewer than this many times are considered rare"),
+        )
+        .arg(
+            clap::Arg::new("dry-run")
+                .long("dry-run")
+                .action(clap::ArgAction::SetTrue)
+                .help("Print what would be removed without writing changes"),
+        )
+        .arg(
+            clap::Arg::new("quiet")
+                .long("quiet")
+                .short('q')
+                .action(clap::ArgAction::SetTrue)
+                .help("Suppress output"),
+        )
+        .arg(
+            clap::Arg::new("remove-rare")
+                .long("remove-rare")
+                .action(clap::ArgAction::SetTrue)
+                .help("Remove commands used fewer than --rare-threshold times"),
+        )
+        .arg(
+            clap::Arg::new("no-log")
+                .long("no-log")
+                .action(clap::ArgAction::SetTrue)
+                .help("Disable cleanup run logging"),
+        )
+        .arg(
+            clap::Arg::new("log-max-bytes")
+                .long("log-max-bytes")
+                .default_value("1048576")
+                .value_parser(clap::value_parser!(u64))
+                .help("Max log file size in bytes before rotation (default: 1 MiB)"),
+        )
+        .subcommand(clap::Command::new("undo").about("Restore history from the latest backup"))
+        .subcommand(
+            clap::Command::new("record-exit")
+                .about("Record exit code of a command (called by the zsh plugin)")
+                .arg(clap::Arg::new("timestamp").required(true))
+                .arg(
+                    clap::Arg::new("exit-code")
+                        .required(true)
+                        .value_parser(clap::value_parser!(i32)),
+                ),
+        )
+        .subcommand(
+            clap::Command::new("explain")
+                .about("Explain why a command would be removed")
+                .arg(clap::Arg::new("command").required(true)),
+        )
+}

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,13 @@
 use std::{env, fs, io};
 
+use clap::{CommandFactory, Parser, Subcommand};
+
+include!("src/cli_definition.rs");
+
 fn main() -> io::Result<()> {
-    let out = env::var_os("OUT_DIR").unwrap();
-    let comp_dir = std::path::Path::new(&out).join("completions");
-    let man_dir = std::path::Path::new(&out).join("man");
+    let manifest = env::var_os("CARGO_MANIFEST_DIR").unwrap();
+    let comp_dir = std::path::Path::new(&manifest).join("completions");
+    let man_dir = std::path::Path::new(&manifest).join("man");
     fs::create_dir_all(&comp_dir)?;
     fs::create_dir_all(&man_dir)?;
 
@@ -14,83 +18,15 @@ fn main() -> io::Result<()> {
         clap_complete::Shell::Elvish,
         clap_complete::Shell::PowerShell,
     ];
-    let mut cmd = cli();
+    let mut cmd = Cli::command();
     for shell in shells {
         clap_complete::generate_to(shell, &mut cmd, "zsh-clean-history", &comp_dir)?;
     }
 
-    let man = clap_mangen::Man::new(cli());
+    let man = clap_mangen::Man::new(Cli::command());
     let mut buf = Vec::<u8>::new();
     man.render(&mut buf)?;
     fs::write(man_dir.join("zsh-clean-history.1"), buf)?;
 
     Ok(())
-}
-
-fn cli() -> clap::Command {
-    clap::Command::new("zsh-clean-history")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about("Smart zsh history cleaner - removes typos and failed commands")
-        .arg(
-            clap::Arg::new("similarity")
-                .long("similarity")
-                .default_value("0.8")
-                .value_parser(clap::value_parser!(f64))
-                .help("Similarity threshold (0.0–1.0) for deduplication"),
-        )
-        .arg(
-            clap::Arg::new("rare-threshold")
-                .long("rare-threshold")
-                .default_value("3")
-                .value_parser(clap::value_parser!(usize))
-                .help("Commands run fewer than this many times are considered rare"),
-        )
-        .arg(
-            clap::Arg::new("dry-run")
-                .long("dry-run")
-                .action(clap::ArgAction::SetTrue)
-                .help("Print what would be removed without writing changes"),
-        )
-        .arg(
-            clap::Arg::new("quiet")
-                .long("quiet")
-                .short('q')
-                .action(clap::ArgAction::SetTrue)
-                .help("Suppress output"),
-        )
-        .arg(
-            clap::Arg::new("remove-rare")
-                .long("remove-rare")
-                .action(clap::ArgAction::SetTrue)
-                .help("Remove commands used fewer than --rare-threshold times"),
-        )
-        .arg(
-            clap::Arg::new("no-log")
-                .long("no-log")
-                .action(clap::ArgAction::SetTrue)
-                .help("Disable cleanup run logging"),
-        )
-        .arg(
-            clap::Arg::new("log-max-bytes")
-                .long("log-max-bytes")
-                .default_value("1048576")
-                .value_parser(clap::value_parser!(u64))
-                .help("Max log file size in bytes before rotation (default: 1 MiB)"),
-        )
-        .subcommand(clap::Command::new("undo").about("Restore history from the latest backup"))
-        .subcommand(
-            clap::Command::new("record-exit")
-                .about("Record exit code of a command (called by the zsh plugin)")
-                .arg(clap::Arg::new("timestamp").required(true))
-                .arg(
-                    clap::Arg::new("exit-code")
-                        .required(true)
-                        .value_parser(clap::value_parser!(i32)),
-                ),
-        )
-        .subcommand(
-            clap::Command::new("explain")
-                .about("Explain why a command would be removed")
-                .arg(clap::Arg::new("command").required(true)),
-        )
 }

--- a/completions/_zsh-clean-history
+++ b/completions/_zsh-clean-history
@@ -1,0 +1,157 @@
+#compdef zsh-clean-history
+
+autoload -U is-at-least
+
+_zsh-clean-history() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" : \
+'--similarity=[Similarity threshold (0.0–1.0) for deduplication]: :_default' \
+'--rare-threshold=[Commands run fewer than this many times are considered rare]: :_default' \
+'--log-max-bytes=[Max log file size in bytes before rotation (default\: 1 MiB)]: :_default' \
+'--dry-run[Print what would be removed without writing changes]' \
+'-q[Suppress output]' \
+'--quiet[Suppress output]' \
+'--remove-rare[Remove commands used fewer than --rare-threshold times]' \
+'--no-log[Disable cleanup run logging]' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_zsh-clean-history_commands" \
+"*::: :->zsh-clean-history" \
+&& ret=0
+    case $state in
+    (zsh-clean-history)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:zsh-clean-history-command-$line[1]:"
+        case $line[1] in
+            (undo)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(record-exit)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+':timestamp:_default' \
+':exit-code:_default' \
+&& ret=0
+;;
+(explain)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+':command:_default' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_zsh-clean-history__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:zsh-clean-history-help-command-$line[1]:"
+        case $line[1] in
+            (undo)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(record-exit)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(explain)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+}
+
+(( $+functions[_zsh-clean-history_commands] )) ||
+_zsh-clean-history_commands() {
+    local commands; commands=(
+'undo:Restore history from the latest backup' \
+'record-exit:Record exit code of a command (called by the zsh plugin)' \
+'explain:Explain why a command would be removed' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'zsh-clean-history commands' commands "$@"
+}
+(( $+functions[_zsh-clean-history__subcmd__explain_commands] )) ||
+_zsh-clean-history__subcmd__explain_commands() {
+    local commands; commands=()
+    _describe -t commands 'zsh-clean-history explain commands' commands "$@"
+}
+(( $+functions[_zsh-clean-history__subcmd__help_commands] )) ||
+_zsh-clean-history__subcmd__help_commands() {
+    local commands; commands=(
+'undo:Restore history from the latest backup' \
+'record-exit:Record exit code of a command (called by the zsh plugin)' \
+'explain:Explain why a command would be removed' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'zsh-clean-history help commands' commands "$@"
+}
+(( $+functions[_zsh-clean-history__subcmd__help__subcmd__explain_commands] )) ||
+_zsh-clean-history__subcmd__help__subcmd__explain_commands() {
+    local commands; commands=()
+    _describe -t commands 'zsh-clean-history help explain commands' commands "$@"
+}
+(( $+functions[_zsh-clean-history__subcmd__help__subcmd__help_commands] )) ||
+_zsh-clean-history__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'zsh-clean-history help help commands' commands "$@"
+}
+(( $+functions[_zsh-clean-history__subcmd__help__subcmd__record-exit_commands] )) ||
+_zsh-clean-history__subcmd__help__subcmd__record-exit_commands() {
+    local commands; commands=()
+    _describe -t commands 'zsh-clean-history help record-exit commands' commands "$@"
+}
+(( $+functions[_zsh-clean-history__subcmd__help__subcmd__undo_commands] )) ||
+_zsh-clean-history__subcmd__help__subcmd__undo_commands() {
+    local commands; commands=()
+    _describe -t commands 'zsh-clean-history help undo commands' commands "$@"
+}
+(( $+functions[_zsh-clean-history__subcmd__record-exit_commands] )) ||
+_zsh-clean-history__subcmd__record-exit_commands() {
+    local commands; commands=()
+    _describe -t commands 'zsh-clean-history record-exit commands' commands "$@"
+}
+(( $+functions[_zsh-clean-history__subcmd__undo_commands] )) ||
+_zsh-clean-history__subcmd__undo_commands() {
+    local commands; commands=()
+    _describe -t commands 'zsh-clean-history undo commands' commands "$@"
+}
+
+if [ "$funcstack[1]" = "_zsh-clean-history" ]; then
+    _zsh-clean-history "$@"
+else
+    compdef _zsh-clean-history zsh-clean-history
+fi

--- a/completions/_zsh-clean-history
+++ b/completions/_zsh-clean-history
@@ -15,14 +15,14 @@ _zsh-clean-history() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" : \
-'--similarity=[Similarity threshold (0.0–1.0) for deduplication]: :_default' \
-'--rare-threshold=[Commands run fewer than this many times are considered rare]: :_default' \
-'--log-max-bytes=[Max log file size in bytes before rotation (default\: 1 MiB)]: :_default' \
-'--dry-run[Print what would be removed without writing changes]' \
-'-q[Suppress output]' \
-'--quiet[Suppress output]' \
-'--remove-rare[Remove commands used fewer than --rare-threshold times]' \
-'--no-log[Disable cleanup run logging]' \
+'--similarity=[]:SIMILARITY:_default' \
+'--rare-threshold=[]:RARE_THRESHOLD:_default' \
+'--log-max-bytes=[]:LOG_MAX_BYTES:_default' \
+'--dry-run[]' \
+'-q[]' \
+'--quiet[]' \
+'--remove-rare[]' \
+'--no-log[]' \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \
@@ -47,7 +47,7 @@ _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 ':timestamp:_default' \
-':exit-code:_default' \
+':exit_code:_default' \
 && ret=0
 ;;
 (explain)
@@ -97,9 +97,9 @@ esac
 (( $+functions[_zsh-clean-history_commands] )) ||
 _zsh-clean-history_commands() {
     local commands; commands=(
-'undo:Restore history from the latest backup' \
-'record-exit:Record exit code of a command (called by the zsh plugin)' \
-'explain:Explain why a command would be removed' \
+'undo:' \
+'record-exit:' \
+'explain:' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'zsh-clean-history commands' commands "$@"
@@ -112,9 +112,9 @@ _zsh-clean-history__subcmd__explain_commands() {
 (( $+functions[_zsh-clean-history__subcmd__help_commands] )) ||
 _zsh-clean-history__subcmd__help_commands() {
     local commands; commands=(
-'undo:Restore history from the latest backup' \
-'record-exit:Record exit code of a command (called by the zsh plugin)' \
-'explain:Explain why a command would be removed' \
+'undo:' \
+'record-exit:' \
+'explain:' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'zsh-clean-history help commands' commands "$@"

--- a/completions/_zsh-clean-history.ps1
+++ b/completions/_zsh-clean-history.ps1
@@ -1,0 +1,80 @@
+
+using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
+
+Register-ArgumentCompleter -Native -CommandName 'zsh-clean-history' -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $commandElements = $commandAst.CommandElements
+    $command = @(
+        'zsh-clean-history'
+        for ($i = 1; $i -lt $commandElements.Count; $i++) {
+            $element = $commandElements[$i]
+            if ($element -isnot [StringConstantExpressionAst] -or
+                $element.StringConstantType -ne [StringConstantType]::BareWord -or
+                $element.Value.StartsWith('-') -or
+                $element.Value -eq $wordToComplete) {
+                break
+        }
+        $element.Value
+    }) -join ';'
+
+    $completions = @(switch ($command) {
+        'zsh-clean-history' {
+            [CompletionResult]::new('--similarity', '--similarity', [CompletionResultType]::ParameterName, 'similarity')
+            [CompletionResult]::new('--rare-threshold', '--rare-threshold', [CompletionResultType]::ParameterName, 'rare-threshold')
+            [CompletionResult]::new('--log-max-bytes', '--log-max-bytes', [CompletionResultType]::ParameterName, 'log-max-bytes')
+            [CompletionResult]::new('--dry-run', '--dry-run', [CompletionResultType]::ParameterName, 'dry-run')
+            [CompletionResult]::new('-q', '-q', [CompletionResultType]::ParameterName, 'q')
+            [CompletionResult]::new('--quiet', '--quiet', [CompletionResultType]::ParameterName, 'quiet')
+            [CompletionResult]::new('--remove-rare', '--remove-rare', [CompletionResultType]::ParameterName, 'remove-rare')
+            [CompletionResult]::new('--no-log', '--no-log', [CompletionResultType]::ParameterName, 'no-log')
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('undo', 'undo', [CompletionResultType]::ParameterValue, 'undo')
+            [CompletionResult]::new('record-exit', 'record-exit', [CompletionResultType]::ParameterValue, 'record-exit')
+            [CompletionResult]::new('explain', 'explain', [CompletionResultType]::ParameterValue, 'explain')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
+            break
+        }
+        'zsh-clean-history;undo' {
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            break
+        }
+        'zsh-clean-history;record-exit' {
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            break
+        }
+        'zsh-clean-history;explain' {
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            break
+        }
+        'zsh-clean-history;help' {
+            [CompletionResult]::new('undo', 'undo', [CompletionResultType]::ParameterValue, 'undo')
+            [CompletionResult]::new('record-exit', 'record-exit', [CompletionResultType]::ParameterValue, 'record-exit')
+            [CompletionResult]::new('explain', 'explain', [CompletionResultType]::ParameterValue, 'explain')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
+            break
+        }
+        'zsh-clean-history;help;undo' {
+            break
+        }
+        'zsh-clean-history;help;record-exit' {
+            break
+        }
+        'zsh-clean-history;help;explain' {
+            break
+        }
+        'zsh-clean-history;help;help' {
+            break
+        }
+    })
+
+    $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
+        Sort-Object -Property ListItemText
+}

--- a/completions/zsh-clean-history.bash
+++ b/completions/zsh-clean-history.bash
@@ -1,0 +1,194 @@
+_zsh-clean-history() {
+    local i cur prev opts cmd
+    COMPREPLY=()
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
+    cmd=""
+    opts=""
+
+    for i in "${COMP_WORDS[@]:0:COMP_CWORD}"
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="zsh__clean__history"
+                ;;
+            zsh__clean__history,explain)
+                cmd="zsh__clean__history__subcmd__explain"
+                ;;
+            zsh__clean__history,help)
+                cmd="zsh__clean__history__subcmd__help"
+                ;;
+            zsh__clean__history,record-exit)
+                cmd="zsh__clean__history__subcmd__record__subcmd__exit"
+                ;;
+            zsh__clean__history,undo)
+                cmd="zsh__clean__history__subcmd__undo"
+                ;;
+            zsh__clean__history__subcmd__help,explain)
+                cmd="zsh__clean__history__subcmd__help__subcmd__explain"
+                ;;
+            zsh__clean__history__subcmd__help,help)
+                cmd="zsh__clean__history__subcmd__help__subcmd__help"
+                ;;
+            zsh__clean__history__subcmd__help,record-exit)
+                cmd="zsh__clean__history__subcmd__help__subcmd__record__subcmd__exit"
+                ;;
+            zsh__clean__history__subcmd__help,undo)
+                cmd="zsh__clean__history__subcmd__help__subcmd__undo"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        zsh__clean__history)
+            opts="-q -h -V --similarity --rare-threshold --dry-run --quiet --remove-rare --no-log --log-max-bytes --help --version undo record-exit explain help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --similarity)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --rare-threshold)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --log-max-bytes)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        zsh__subcmd__clean__subcmd__history__subcmd__explain)
+            opts="-h --help <COMMAND>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        zsh__subcmd__clean__subcmd__history__subcmd__help)
+            opts="undo record-exit explain help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        zsh__subcmd__clean__subcmd__history__subcmd__help__subcmd__explain)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        zsh__subcmd__clean__subcmd__history__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        zsh__subcmd__clean__subcmd__history__subcmd__help__subcmd__record__subcmd__exit)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        zsh__subcmd__clean__subcmd__history__subcmd__help__subcmd__undo)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        zsh__subcmd__clean__subcmd__history__subcmd__record__subcmd__exit)
+            opts="-h --help <TIMESTAMP> <EXIT_CODE>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        zsh__subcmd__clean__subcmd__history__subcmd__undo)
+            opts="-h --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -F _zsh-clean-history -o nosort -o bashdefault -o default zsh-clean-history
+else
+    complete -F _zsh-clean-history -o bashdefault -o default zsh-clean-history
+fi

--- a/completions/zsh-clean-history.elv
+++ b/completions/zsh-clean-history.elv
@@ -1,0 +1,66 @@
+
+use builtin;
+use str;
+
+set edit:completion:arg-completer[zsh-clean-history] = {|@words|
+    fn spaces {|n|
+        builtin:repeat $n ' ' | str:join ''
+    }
+    fn cand {|text desc|
+        edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
+    }
+    var command = 'zsh-clean-history'
+    for word $words[1..-1] {
+        if (str:has-prefix $word '-') {
+            break
+        }
+        set command = $command';'$word
+    }
+    var completions = [
+        &'zsh-clean-history'= {
+            cand --similarity 'similarity'
+            cand --rare-threshold 'rare-threshold'
+            cand --log-max-bytes 'log-max-bytes'
+            cand --dry-run 'dry-run'
+            cand -q 'q'
+            cand --quiet 'quiet'
+            cand --remove-rare 'remove-rare'
+            cand --no-log 'no-log'
+            cand -h 'Print help'
+            cand --help 'Print help'
+            cand -V 'Print version'
+            cand --version 'Print version'
+            cand undo 'undo'
+            cand record-exit 'record-exit'
+            cand explain 'explain'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'zsh-clean-history;undo'= {
+            cand -h 'Print help'
+            cand --help 'Print help'
+        }
+        &'zsh-clean-history;record-exit'= {
+            cand -h 'Print help'
+            cand --help 'Print help'
+        }
+        &'zsh-clean-history;explain'= {
+            cand -h 'Print help'
+            cand --help 'Print help'
+        }
+        &'zsh-clean-history;help'= {
+            cand undo 'undo'
+            cand record-exit 'record-exit'
+            cand explain 'explain'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'zsh-clean-history;help;undo'= {
+        }
+        &'zsh-clean-history;help;record-exit'= {
+        }
+        &'zsh-clean-history;help;explain'= {
+        }
+        &'zsh-clean-history;help;help'= {
+        }
+    ]
+    $completions[$command]
+}

--- a/completions/zsh-clean-history.fish
+++ b/completions/zsh-clean-history.fish
@@ -1,0 +1,46 @@
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_zsh_clean_history_global_optspecs
+	string join \n similarity= rare-threshold= dry-run q/quiet remove-rare no-log log-max-bytes= h/help V/version
+end
+
+function __fish_zsh_clean_history_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_zsh_clean_history_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_zsh_clean_history_using_subcommand
+	set -l cmd (__fish_zsh_clean_history_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -l similarity -r
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -l rare-threshold -r
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -l log-max-bytes -r
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -l dry-run
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -s q -l quiet
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -l remove-rare
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -l no-log
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -s h -l help -d 'Print help'
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -s V -l version -d 'Print version'
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -f -a "undo"
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -f -a "record-exit"
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -f -a "explain"
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_using_subcommand undo" -s h -l help -d 'Print help'
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_using_subcommand record-exit" -s h -l help -d 'Print help'
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_using_subcommand explain" -s h -l help -d 'Print help'
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_using_subcommand help; and not __fish_seen_subcommand_from undo record-exit explain help" -f -a "undo"
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_using_subcommand help; and not __fish_seen_subcommand_from undo record-exit explain help" -f -a "record-exit"
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_using_subcommand help; and not __fish_seen_subcommand_from undo record-exit explain help" -f -a "explain"
+complete -c zsh-clean-history -n "__fish_zsh_clean_history_using_subcommand help; and not __fish_seen_subcommand_from undo record-exit explain help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/man/zsh-clean-history.1
+++ b/man/zsh-clean-history.1
@@ -1,0 +1,49 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH zsh-clean-history 1  "zsh-clean-history 0.1.0" 
+.SH NAME
+zsh\-clean\-history \- Smart zsh history cleaner \- removes typos and failed commands
+.SH SYNOPSIS
+\fBzsh\-clean\-history\fR [\fB\-\-similarity\fR] [\fB\-\-rare\-threshold\fR] [\fB\-\-dry\-run\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-\-remove\-rare\fR] [\fB\-\-no\-log\fR] [\fB\-\-log\-max\-bytes\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
+.SH DESCRIPTION
+Smart zsh history cleaner \- removes typos and failed commands
+.SH OPTIONS
+.TP
+\fB\-\-similarity\fR \fI<SIMILARITY>\fR [default: 0.8]
+
+.TP
+\fB\-\-rare\-threshold\fR \fI<RARE_THRESHOLD>\fR [default: 3]
+
+.TP
+\fB\-\-dry\-run\fR
+
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR
+
+.TP
+\fB\-\-remove\-rare\fR
+
+.TP
+\fB\-\-no\-log\fR
+
+.TP
+\fB\-\-log\-max\-bytes\fR \fI<LOG_MAX_BYTES>\fR [default: 1048576]
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version
+.SH SUBCOMMANDS
+.TP
+zsh\-clean\-history\-undo(1)
+.TP
+zsh\-clean\-history\-record\-exit(1)
+.TP
+zsh\-clean\-history\-explain(1)
+.TP
+zsh\-clean\-history\-help(1)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.1.0

--- a/src/cli_definition.rs
+++ b/src/cli_definition.rs
@@ -1,0 +1,37 @@
+// Shared CLI definition — included by both src/main.rs and build.rs via include!().
+// Keep this file free of dependencies on the zsh_clean_history lib so build.rs
+// can include it without a circular dependency.
+
+const DEFAULT_LOG_MAX_BYTES: u64 = 1_048_576;
+
+#[derive(Parser)]
+#[command(
+    name = "zsh-clean-history",
+    version,
+    about = "Smart zsh history cleaner - removes typos and failed commands"
+)]
+struct Cli {
+    #[arg(long, default_value_t = 0.8)]
+    similarity: f64,
+    #[arg(long, default_value_t = 3)]
+    rare_threshold: usize,
+    #[arg(long)]
+    dry_run: bool,
+    #[arg(long, short)]
+    quiet: bool,
+    #[arg(long)]
+    remove_rare: bool,
+    #[arg(long)]
+    no_log: bool,
+    #[arg(long, default_value_t = DEFAULT_LOG_MAX_BYTES)]
+    log_max_bytes: u64,
+    #[command(subcommand)]
+    cmd: Option<Cmd>,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    Undo,
+    RecordExit { timestamp: String, exit_code: i32 },
+    Explain { command: String },
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,41 +10,17 @@ use fs2::FileExt;
 use tempfile::NamedTempFile;
 use zsh_clean_history::cleaner::Removal;
 use zsh_clean_history::{
-    CleaningSettings, DEFAULT_LOG_MAX_BYTES, Paths, compact_exits_file, identify_removals,
-    load_exit_codes, parse_history_file, write_log_entry,
+    CleaningSettings, Paths, compact_exits_file, identify_removals, load_exit_codes,
+    parse_history_file, write_log_entry,
 };
 
-#[derive(Parser)]
-#[command(
-    name = "zsh-clean-history",
-    version,
-    about = "Smart zsh history cleaner - removes typos and failed commands"
-)]
-struct Cli {
-    #[arg(long, default_value_t = 0.8)]
-    similarity: f64,
-    #[arg(long, default_value_t = 3)]
-    rare_threshold: usize,
-    #[arg(long)]
-    dry_run: bool,
-    #[arg(long, short)]
-    quiet: bool,
-    #[arg(long)]
-    remove_rare: bool,
-    #[arg(long)]
-    no_log: bool,
-    #[arg(long, default_value_t = DEFAULT_LOG_MAX_BYTES)]
-    log_max_bytes: u64,
-    #[command(subcommand)]
-    cmd: Option<Cmd>,
-}
+include!("cli_definition.rs");
 
-#[derive(Subcommand)]
-enum Cmd {
-    Undo,
-    RecordExit { timestamp: String, exit_code: i32 },
-    Explain { command: String },
-}
+// Compile-time guard: keeps cli_definition.rs in sync with log.rs
+const _: () = assert!(
+    zsh_clean_history::DEFAULT_LOG_MAX_BYTES == DEFAULT_LOG_MAX_BYTES,
+    "Update DEFAULT_LOG_MAX_BYTES in cli_definition.rs to match log.rs"
+);
 
 fn main() -> Result<()> {
     let cli = Cli::parse();


### PR DESCRIPTION
## Motivation

Users had no shell completions or manpage for `zsh-clean-history`, making discovery of flags and subcommands cumbersome. This adds first-class distribution artifacts generated at build time.

Closes https://github.com/Automaat/zsh-clean-history/issues/34

## Implementation information

- Added `build.rs` using `clap_complete` to generate completions for zsh, bash, fish, elvish, and PowerShell at compile time
- Added manpage generation via `clap_mangen` in `build.rs`
- Committed generated artifacts under `completions/` and `man/` so they ship without requiring a build step
- Also includes several feature additions made alongside: secret-pattern redaction, log rotation (`--log-max-bytes`), async plugin cleanup on exit, microsecond timestamps, tokenized similarity comparison, and `explain` subcommand