### PR TITLE
feat(core): normalize volatile tokens

### DIFF
--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -12,22 +12,37 @@ fn norm_patterns() -> &'static [(Regex, &'static str)] {
         vec![
             (Regex::new(r"^https?://").unwrap(), "<URL>"),
             (Regex::new(r"^/").unwrap(), "<PATH>"),
-            (Regex::new(r"^v\d+\.\d+\.\d+").unwrap(), "<VER>"),
+            (Regex::new(r"^v\d+\.\d+\.\d+$").unwrap(), "<VER>"),
             (Regex::new(r"^[0-9a-fA-F]{6,}$").unwrap(), "<SHA>"),
         ]
     })
 }
 
+/// Strip symmetric single or double shell quotes from a token.
+fn strip_shell_quotes(tok: &str) -> &str {
+    let b = tok.as_bytes();
+    if b.len() >= 2 {
+        let (first, last) = (b[0], b[b.len() - 1]);
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return &tok[1..tok.len() - 1];
+        }
+    }
+    tok
+}
+
 /// Normalise volatile tokens in a command string for similarity comparison.
 ///
 /// Replaces hex SHAs (≥6 hex chars), absolute paths (`/…`), URLs (`https?://…`),
-/// and semver strings (`vN.N.N`) with stable placeholders so that structurally
+/// and exact semver tags (`vN.N.N`) with stable placeholders so that structurally
 /// identical commands with different concrete values are not mistaken for typos.
+/// Symmetric shell quotes are stripped before classification so that quoted args
+/// like `"https://…"` or `'/tmp/…'` are normalised the same as unquoted ones.
 pub(crate) fn normalize(s: &str) -> String {
     s.split_whitespace()
         .map(|tok| {
+            let inner = strip_shell_quotes(tok);
             for (re, placeholder) in norm_patterns() {
-                if re.is_match(tok) {
+                if re.is_match(inner) {
                     return placeholder.to_string();
                 }
             }
@@ -245,6 +260,59 @@ mod tests {
         assert!(command_similar(
             "git checkot abc123",
             "git checkout abc123",
+            0.8
+        ));
+    }
+
+    // --- quoted token normalization ---
+
+    #[test]
+    fn normalize_double_quoted_url_replaced() {
+        assert_eq!(
+            normalize(r#"curl "https://api.example.com""#),
+            "curl <URL>"
+        );
+    }
+
+    #[test]
+    fn normalize_single_quoted_path_replaced() {
+        assert_eq!(normalize("ls '/home/user'"), "ls <PATH>");
+    }
+
+    #[test]
+    fn normalize_double_quoted_sha_replaced() {
+        assert_eq!(normalize(r#"git checkout "abc1234""#), "git checkout <SHA>");
+    }
+
+    #[test]
+    fn normalize_single_quoted_semver_replaced() {
+        assert_eq!(normalize("git checkout 'v1.2.3'"), "git checkout <VER>");
+    }
+
+    // --- semver anchoring ---
+
+    #[test]
+    fn normalize_semver_prerelease_not_replaced() {
+        assert_eq!(
+            normalize("git checkout v1.2.3-rc1"),
+            "git checkout v1.2.3-rc1"
+        );
+    }
+
+    #[test]
+    fn normalize_semver_suffix_not_replaced() {
+        assert_eq!(
+            normalize("git checkout v1.2.3-hotfix"),
+            "git checkout v1.2.3-hotfix"
+        );
+    }
+
+    #[test]
+    fn semver_prerelease_branches_not_collapsed() {
+        // v1.2.3-rc1 and v1.2.3-rc2 must remain distinct after normalization
+        assert!(!command_similar(
+            "git checkout v1.2.3-rc1",
+            "git checkout v1.2.3-rc2",
             0.8
         ));
     }

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -1,6 +1,41 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
 use strsim::damerau_levenshtein;
 
 const FALLBACK_THRESHOLD: f64 = 0.95;
+
+static NORM_PATTERNS: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
+
+fn norm_patterns() -> &'static [(Regex, &'static str)] {
+    NORM_PATTERNS.get_or_init(|| {
+        vec![
+            (Regex::new(r"^https?://").unwrap(), "<URL>"),
+            (Regex::new(r"^/").unwrap(), "<PATH>"),
+            (Regex::new(r"^v\d+\.\d+\.\d+").unwrap(), "<VER>"),
+            (Regex::new(r"^[0-9a-fA-F]{6,}$").unwrap(), "<SHA>"),
+        ]
+    })
+}
+
+/// Normalise volatile tokens in a command string for similarity comparison.
+///
+/// Replaces hex SHAs (≥6 hex chars), absolute paths (`/…`), URLs (`https?://…`),
+/// and semver strings (`vN.N.N`) with stable placeholders so that structurally
+/// identical commands with different concrete values are not mistaken for typos.
+pub(crate) fn normalize(s: &str) -> String {
+    s.split_whitespace()
+        .map(|tok| {
+            for (re, placeholder) in norm_patterns() {
+                if re.is_match(tok) {
+                    return placeholder.to_string();
+                }
+            }
+            tok.to_string()
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
 
 // Intentionally crate-private: the public API exposes `command_similar`;
 // raw ratio values are an implementation detail not guaranteed to be stable.
@@ -48,14 +83,16 @@ pub(crate) fn command_similar(failed: &str, success: &str, threshold: f64) -> bo
     if failed == success {
         return false;
     }
-    let (failed_head, failed_rest) = command_split(failed);
-    let (success_head, success_rest) = command_split(success);
+    let failed_norm = normalize(failed);
+    let success_norm = normalize(success);
+    let (failed_head, failed_rest) = command_split(&failed_norm);
+    let (success_head, success_rest) = command_split(&success_norm);
     let head_sim = ratio(&failed_head, &success_head);
     if head_sim >= threshold && head_sim < 1.0 {
         if failed_rest == success_rest {
             return true;
         }
-        return ratio(failed, success) >= FALLBACK_THRESHOLD;
+        return ratio(&failed_norm, &success_norm) >= FALLBACK_THRESHOLD;
     }
     false
 }
@@ -143,6 +180,71 @@ mod tests {
         assert!(!command_similar(
             "git cmmit --amned",
             "git commit --amend",
+            0.8
+        ));
+    }
+
+    // --- normalize unit tests ---
+
+    #[test]
+    fn normalize_hex_sha_replaced() {
+        assert_eq!(normalize("git checkout abc123"), "git checkout <SHA>");
+    }
+
+    #[test]
+    fn normalize_hex_below_min_len_kept() {
+        assert_eq!(normalize("foo abcde"), "foo abcde");
+    }
+
+    #[test]
+    fn normalize_absolute_path_replaced() {
+        assert_eq!(normalize("ls /home/user"), "ls <PATH>");
+    }
+
+    #[test]
+    fn normalize_url_replaced() {
+        assert_eq!(normalize("curl https://example.com/api"), "curl <URL>");
+    }
+
+    #[test]
+    fn normalize_http_url_replaced() {
+        assert_eq!(normalize("curl http://example.com"), "curl <URL>");
+    }
+
+    #[test]
+    fn normalize_semver_replaced() {
+        assert_eq!(normalize("git checkout v1.2.3"), "git checkout <VER>");
+    }
+
+    // --- command_similar behaviour with normalised tokens ---
+
+    #[test]
+    fn sha_args_not_similar() {
+        assert!(!command_similar("git checkout abc123", "git checkout def456", 0.8));
+    }
+
+    #[test]
+    fn path_args_not_similar() {
+        // /home/user1 ends up in head (second word) — normalization collapses both
+        // to "ls <PATH>" so head_sim == 1.0 and the pair is not flagged
+        assert!(!command_similar("ls /home/user1", "ls /home/user2", 0.8));
+    }
+
+    #[test]
+    fn url_args_not_similar() {
+        assert!(!command_similar(
+            "curl https://api.example.com/v1",
+            "curl https://api.other.com/v2",
+            0.8
+        ));
+    }
+
+    #[test]
+    fn typo_with_sha_arg_still_caught() {
+        // head typo ("checkot") + same logical arg (both SHA) → still flagged
+        assert!(command_similar(
+            "git checkot abc123",
+            "git checkout abc123",
             0.8
         ));
     }

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -235,7 +235,11 @@ mod tests {
 
     #[test]
     fn sha_args_not_similar() {
-        assert!(!command_similar("git checkout abc123", "git checkout def456", 0.8));
+        assert!(!command_similar(
+            "git checkout abc123",
+            "git checkout def456",
+            0.8
+        ));
     }
 
     #[test]
@@ -268,10 +272,7 @@ mod tests {
 
     #[test]
     fn normalize_double_quoted_url_replaced() {
-        assert_eq!(
-            normalize(r#"curl "https://api.example.com""#),
-            "curl <URL>"
-        );
+        assert_eq!(normalize(r#"curl "https://api.example.com""#), "curl <URL>");
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Structurally identical commands with different concrete values (hex SHAs, absolute paths, URLs, semver strings) were triggering false-positive similarity matches, causing valid history entries to be incorrectly flagged as duplicates or typos.

## Implementation information

- Added `normalize()` in `src/similarity.rs` that masks hex SHAs (≥6 chars), absolute paths, URLs, and semver strings with stable placeholders before comparison
- Applied normalization inside `command_similar()` on full command strings before splitting and comparing
- Fixed two normalization gaps in a follow-up: anchored the semver regex (`^v\d+\.\d+\.\d+$`) to handle prerelease suffixes, and added `strip_shell_quotes()` so quoted args (`"https://…"`, `'/tmp/…'`) are classified correctly before regex matching
- Added 7 tests covering quoted URL/path/SHA/semver and prerelease semver anchoring

Closes https://github.com/Automaat/zsh-clean-history/issues/37