### PR TITLE
refactor(core): move backup/write/prune into clean.rs

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -44,7 +44,11 @@ impl Drop for LockedHistory {
     }
 }
 
-pub fn run_cleanup(paths: &Paths, settings: &CleaningSettings, dry_run: bool) -> Result<CleanReport> {
+pub fn run_cleanup(
+    paths: &Paths,
+    settings: &CleaningSettings,
+    dry_run: bool,
+) -> Result<CleanReport> {
     let _lock = LockedHistory::acquire(&paths.lock_file())?;
 
     let exit_codes = load_exit_codes(&paths.exits)?;
@@ -79,7 +83,10 @@ pub fn run_cleanup(paths: &Paths, settings: &CleaningSettings, dry_run: bool) ->
         compact_exits_file(&paths.exits, &keep_ts)?;
     }
 
-    Ok(CleanReport { removals, total_lines })
+    Ok(CleanReport {
+        removals,
+        total_lines,
+    })
 }
 
 pub(crate) fn removals_set(removals: &[Removal]) -> HashSet<usize> {
@@ -218,7 +225,9 @@ mod tests {
         fs::write(&history, b"").unwrap();
 
         for i in 1..=7u32 {
-            let backup = dir.path().join(format!(".zsh_history.backup-20240101-{i:06}"));
+            let backup = dir
+                .path()
+                .join(format!(".zsh_history.backup-20240101-{i:06}"));
             fs::write(&backup, b"").unwrap();
         }
 
@@ -245,7 +254,9 @@ mod tests {
         fs::write(&history, b"").unwrap();
 
         for i in 1..=3u32 {
-            let backup = dir.path().join(format!(".zsh_history.backup-20240101-{i:06}"));
+            let backup = dir
+                .path()
+                .join(format!(".zsh_history.backup-20240101-{i:06}"));
             fs::write(&backup, b"").unwrap();
         }
 
@@ -254,7 +265,11 @@ mod tests {
         let count = fs::read_dir(dir.path())
             .unwrap()
             .filter_map(|e| e.ok())
-            .filter(|e| e.file_name().to_string_lossy().starts_with(".zsh_history.backup-"))
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with(".zsh_history.backup-")
+            })
             .count();
 
         assert_eq!(count, 3);

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -1,0 +1,262 @@
+use std::collections::HashSet;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::Local;
+use fs2::FileExt;
+use tempfile::NamedTempFile;
+
+use crate::cleaner::Removal;
+use crate::{
+    CleaningSettings, HistoryEntry, Paths, compact_exits_file, identify_removals, load_exit_codes,
+    parse_history_file,
+};
+
+pub struct CleanReport {
+    pub removals: Vec<Removal>,
+    pub total_lines: usize,
+}
+
+pub struct LockedHistory {
+    file: fs::File,
+}
+
+impl LockedHistory {
+    pub fn acquire(path: &Path) -> Result<Self> {
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .with_context(|| format!("open {} for lock", path.display()))?;
+        file.lock_exclusive()
+            .with_context(|| format!("lock {}", path.display()))?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for LockedHistory {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+pub fn run_cleanup(paths: &Paths, settings: &CleaningSettings, dry_run: bool) -> Result<CleanReport> {
+    let _lock = LockedHistory::acquire(&paths.lock_file())?;
+
+    let exit_codes = load_exit_codes(&paths.exits)?;
+    let parsed = parse_history_file(&paths.history, &exit_codes)?;
+    let removals = identify_removals(&parsed, settings);
+    let total_lines = parsed.entries.len();
+    let drop_set = removals_set(&removals);
+
+    if !dry_run && !removals.is_empty() {
+        let backup = paths.backup_for(&Local::now().format("%Y%m%d-%H%M%S").to_string());
+        if paths.history.exists() {
+            fs::copy(&paths.history, &backup)
+                .with_context(|| format!("create backup at {}", backup.display()))?;
+            prune_old_backups(&paths.history, 5)?;
+        }
+        write_history_atomically(&paths.history, &parsed.entries, &drop_set)?;
+    }
+
+    if !dry_run {
+        let keep_ts: HashSet<String> = parsed
+            .entries
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, e)| {
+                if drop_set.contains(&idx) {
+                    None
+                } else {
+                    e.timestamp.clone()
+                }
+            })
+            .collect();
+        compact_exits_file(&paths.exits, &keep_ts)?;
+    }
+
+    Ok(CleanReport { removals, total_lines })
+}
+
+pub(crate) fn removals_set(removals: &[Removal]) -> HashSet<usize> {
+    removals.iter().map(|r| r.line).collect()
+}
+
+pub(crate) fn write_history_atomically(
+    path: &Path,
+    entries: &[HistoryEntry],
+    drop_set: &HashSet<usize>,
+) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = NamedTempFile::new_in(parent)?;
+    for (idx, entry) in entries.iter().enumerate() {
+        if drop_set.contains(&idx) {
+            continue;
+        }
+        tmp.write_all(entry.raw.as_bytes())?;
+        tmp.write_all(b"\n")?;
+    }
+    tmp.as_file().sync_all()?;
+    tmp.persist(path).map_err(|e| e.error)?;
+    fs::File::open(parent)?.sync_all()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+pub(crate) fn prune_old_backups(history: &Path, keep: usize) -> Result<()> {
+    let parent = history.parent().unwrap_or_else(|| Path::new("."));
+    let prefix = format!(
+        "{}.backup-",
+        history
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(".zsh_history")
+    );
+    let mut backups: Vec<PathBuf> = fs::read_dir(parent)?
+        .filter_map(|r| r.ok().map(|e| e.path()))
+        .filter(|p| {
+            p.file_name()
+                .and_then(|s| s.to_str())
+                .map(|n| n.starts_with(&prefix))
+                .unwrap_or(false)
+        })
+        .collect();
+    backups.sort();
+    if backups.len() > keep {
+        let drop_count = backups.len() - keep;
+        for path in backups.into_iter().take(drop_count) {
+            let _ = fs::remove_file(path);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use crate::cleaner::Removal;
+    use crate::history::HistoryEntry;
+
+    use super::{prune_old_backups, removals_set, write_history_atomically};
+
+    fn make_entry(raw: &str) -> HistoryEntry {
+        HistoryEntry {
+            raw: raw.to_string(),
+            timestamp: None,
+            command: None,
+        }
+    }
+
+    fn make_removal(line: usize) -> Removal {
+        Removal {
+            line,
+            reason: "duplicate".to_string(),
+            command: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn removals_set_empty() {
+        assert!(removals_set(&[]).is_empty());
+    }
+
+    #[test]
+    fn removals_set_collects_lines() {
+        let removals = vec![make_removal(0), make_removal(3), make_removal(7)];
+        let set = removals_set(&removals);
+        assert!(set.contains(&0));
+        assert!(set.contains(&3));
+        assert!(set.contains(&7));
+        assert!(!set.contains(&1));
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn write_history_atomically_skips_dropped() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("history");
+        let entries = vec![
+            make_entry(": 1:0;ls"),
+            make_entry(": 2:0;pwd"),
+            make_entry(": 3:0;echo hi"),
+        ];
+        let drop_set: HashSet<usize> = [1].into_iter().collect();
+        write_history_atomically(&path, &entries, &drop_set).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains(": 1:0;ls"));
+        assert!(!content.contains(": 2:0;pwd"));
+        assert!(content.contains(": 3:0;echo hi"));
+    }
+
+    #[test]
+    fn write_history_atomically_all_dropped_produces_empty_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("history");
+        let entries = vec![make_entry(": 1:0;ls"), make_entry(": 2:0;pwd")];
+        let drop_set: HashSet<usize> = [0, 1].into_iter().collect();
+        write_history_atomically(&path, &entries, &drop_set).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.is_empty());
+    }
+
+    #[test]
+    fn prune_old_backups_keeps_newest() {
+        let dir = TempDir::new().unwrap();
+        let history = dir.path().join(".zsh_history");
+        fs::write(&history, b"").unwrap();
+
+        for i in 1..=7u32 {
+            let backup = dir.path().join(format!(".zsh_history.backup-20240101-{i:06}"));
+            fs::write(&backup, b"").unwrap();
+        }
+
+        prune_old_backups(&history, 3).unwrap();
+
+        let mut remaining: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|n| n.starts_with(".zsh_history.backup-"))
+            .collect();
+        remaining.sort();
+
+        assert_eq!(remaining.len(), 3);
+        assert!(remaining[0].contains("-000005"));
+        assert!(remaining[1].contains("-000006"));
+        assert!(remaining[2].contains("-000007"));
+    }
+
+    #[test]
+    fn prune_old_backups_noop_when_under_limit() {
+        let dir = TempDir::new().unwrap();
+        let history = dir.path().join(".zsh_history");
+        fs::write(&history, b"").unwrap();
+
+        for i in 1..=3u32 {
+            let backup = dir.path().join(format!(".zsh_history.backup-20240101-{i:06}"));
+            fs::write(&backup, b"").unwrap();
+        }
+
+        prune_old_backups(&history, 5).unwrap();
+
+        let count = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".zsh_history.backup-"))
+            .count();
+
+        assert_eq!(count, 3);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod clean;
 pub mod cleaner;
 pub mod exits;
 pub mod history;
@@ -7,6 +8,7 @@ pub(crate) mod secrets;
 pub mod settings;
 pub mod similarity;
 
+pub use clean::{CleanReport, LockedHistory, run_cleanup};
 pub use cleaner::{Removal, identify_removals};
 pub use exits::{compact_exits_file, load_exit_codes};
 pub use history::{HistoryEntry, ParsedHistory, parse_history_file, parse_history_text};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,13 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use chrono::Local;
 use clap::{Parser, Subcommand};
-use fs2::FileExt;
-use tempfile::NamedTempFile;
+use zsh_clean_history::clean::{LockedHistory, run_cleanup};
 use zsh_clean_history::cleaner::Removal;
 use zsh_clean_history::{
-    CleaningSettings, Paths, compact_exits_file, identify_removals, load_exit_codes,
-    parse_history_file, write_log_entry,
+    CleaningSettings, Paths, identify_removals, load_exit_codes, parse_history_file, write_log_entry,
 };
 
 include!("cli_definition.rs");
@@ -33,7 +29,7 @@ fn main() -> Result<()> {
             exit_code,
         }) => zsh_clean_history::exits::append_exit(&paths.exits, &timestamp, exit_code),
         Some(Cmd::Explain { ref command }) => explain(command, &cli, &paths),
-        None => run_cleanup(&cli, &paths),
+        None => do_cleanup(&cli, &paths),
     }
 }
 
@@ -45,50 +41,17 @@ fn settings_from_cli(cli: &Cli) -> CleaningSettings {
     }
 }
 
-fn run_cleanup(cli: &Cli, paths: &Paths) -> Result<()> {
+fn do_cleanup(cli: &Cli, paths: &Paths) -> Result<()> {
     let settings = settings_from_cli(cli);
-
-    let _lock = LockedHistory::acquire(&paths.lock_file())?;
-
-    let exit_codes = load_exit_codes(&paths.exits)?;
-    let parsed = parse_history_file(&paths.history, &exit_codes)?;
-    let removals = identify_removals(&parsed, &settings);
-    let total_lines = parsed.entries.len();
-    let drop_set = removals_set(&removals);
-
-    if !cli.dry_run && !removals.is_empty() {
-        let backup = paths.backup_for(&Local::now().format("%Y%m%d-%H%M%S").to_string());
-        if paths.history.exists() {
-            fs::copy(&paths.history, &backup)
-                .with_context(|| format!("create backup at {}", backup.display()))?;
-            prune_old_backups(&paths.history, 5)?;
-        }
-        write_history_atomically(&paths.history, &parsed.entries, &drop_set)?;
-    }
-
-    if !cli.dry_run {
-        let keep_ts: HashSet<String> = parsed
-            .entries
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, e)| {
-                if drop_set.contains(&idx) {
-                    None
-                } else {
-                    e.timestamp.clone()
-                }
-            })
-            .collect();
-        compact_exits_file(&paths.exits, &keep_ts)?;
-    }
+    let report = run_cleanup(paths, &settings, cli.dry_run)?;
 
     if !cli.no_log {
         if let Err(e) = write_log_entry(
             &paths.log,
             &settings,
             cli.dry_run,
-            total_lines,
-            &removals,
+            report.total_lines,
+            &report.removals,
             cli.log_max_bytes,
         ) {
             eprintln!("warning: could not write log: {e}");
@@ -96,7 +59,7 @@ fn run_cleanup(cli: &Cli, paths: &Paths) -> Result<()> {
     }
 
     if !cli.quiet {
-        if removals.is_empty() {
+        if report.removals.is_empty() {
             println!("No commands to remove");
         } else {
             let action = if cli.dry_run {
@@ -104,9 +67,9 @@ fn run_cleanup(cli: &Cli, paths: &Paths) -> Result<()> {
             } else {
                 "Removed"
             };
-            println!("\n{action} {} lines:", removals.len());
+            println!("\n{action} {} lines:", report.removals.len());
             let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
-            for r in &removals {
+            for r in &report.removals {
                 *counts.entry(r.reason.as_str()).or_default() += 1;
             }
             let mut entries: Vec<_> = counts.into_iter().collect();
@@ -114,7 +77,8 @@ fn run_cleanup(cli: &Cli, paths: &Paths) -> Result<()> {
             for (reason, count) in &entries {
                 println!("  {reason}: {count}");
                 if cli.dry_run && cli.verbose {
-                    for sample in removals
+                    for sample in report
+                        .removals
                         .iter()
                         .filter(|r| r.reason.as_str() == *reason)
                         .take(5)
@@ -177,63 +141,6 @@ fn truncate_cmd(cmd: &str, max_chars: usize) -> String {
     }
 }
 
-fn write_history_atomically(
-    path: &Path,
-    entries: &[zsh_clean_history::HistoryEntry],
-    drop_set: &HashSet<usize>,
-) -> Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = NamedTempFile::new_in(parent)?;
-    for (idx, entry) in entries.iter().enumerate() {
-        if drop_set.contains(&idx) {
-            continue;
-        }
-        tmp.write_all(entry.raw.as_bytes())?;
-        tmp.write_all(b"\n")?;
-    }
-    tmp.as_file().sync_all()?;
-    tmp.persist(path).map_err(|e| e.error)?;
-    fs::File::open(parent)?.sync_all()?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
-    }
-    Ok(())
-}
-
-fn removals_set(removals: &[Removal]) -> HashSet<usize> {
-    removals.iter().map(|r| r.line).collect()
-}
-
-fn prune_old_backups(history: &Path, keep: usize) -> Result<()> {
-    let parent = history.parent().unwrap_or_else(|| Path::new("."));
-    let prefix = format!(
-        "{}.backup-",
-        history
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or(".zsh_history")
-    );
-    let mut backups: Vec<PathBuf> = fs::read_dir(parent)?
-        .filter_map(|r| r.ok().map(|e| e.path()))
-        .filter(|p| {
-            p.file_name()
-                .and_then(|s| s.to_str())
-                .map(|n| n.starts_with(&prefix))
-                .unwrap_or(false)
-        })
-        .collect();
-    backups.sort();
-    if backups.len() > keep {
-        let drop_count = backups.len() - keep;
-        for path in backups.into_iter().take(drop_count) {
-            let _ = fs::remove_file(path);
-        }
-    }
-    Ok(())
-}
-
 fn undo(paths: &Paths) -> Result<()> {
     let _lock = LockedHistory::acquire(&paths.lock_file())?;
     let parent = paths
@@ -270,29 +177,4 @@ fn undo(paths: &Paths) -> Result<()> {
         latest.display()
     );
     Ok(())
-}
-
-struct LockedHistory {
-    file: fs::File,
-}
-
-impl LockedHistory {
-    fn acquire(path: &Path) -> Result<Self> {
-        let file = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(path)
-            .with_context(|| format!("open {} for lock", path.display()))?;
-        file.lock_exclusive()
-            .with_context(|| format!("lock {}", path.display()))?;
-        Ok(Self { file })
-    }
-}
-
-impl Drop for LockedHistory {
-    fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.file);
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,8 @@ use clap::{Parser, Subcommand};
 use zsh_clean_history::clean::{LockedHistory, run_cleanup};
 use zsh_clean_history::cleaner::Removal;
 use zsh_clean_history::{
-    CleaningSettings, Paths, identify_removals, load_exit_codes, parse_history_file, write_log_entry,
+    CleaningSettings, Paths, identify_removals, load_exit_codes, parse_history_file,
+    write_log_entry,
 };
 
 include!("cli_definition.rs");


### PR DESCRIPTION
## Motivation

`main.rs` was handling too many concerns: atomic writes, backup pruning, history locking, and cleanup orchestration alongside flag parsing and report printing. This made it harder to test individual pieces in isolation and kept growing with each new feature.

## Implementation information

Extracted `write_history_atomically`, `prune_old_backups`, `removals_set`, `LockedHistory`, and the cleanup orchestration into a new `src/clean.rs` module, exposing a single `run_cleanup(paths, settings, dry_run) -> Result<CleanReport>` entry point.

`main.rs` now only handles flag parsing and report printing. Unit tests were added for each extracted helper to cover the logic directly without going through the CLI.

Closes https://github.com/Automaat/zsh-clean-history/issues/42