### PR TITLE
feat(core): add ~/.zsh_history_keep allowlist support

### DIFF
--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+
+use anyhow::Result;
+use regex::RegexSet;
+
+/// Loads `~/.zsh_history_keep`: one regex per line, lines starting with `#` are comments.
+/// Returns `None` if the file does not exist.
+pub fn load_allowlist(path: &Path) -> Result<Option<RegexSet>> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    let patterns: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && !s.starts_with('#'))
+        .collect();
+    if patterns.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(RegexSet::new(patterns)?))
+}

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -8,6 +8,7 @@ use chrono::Local;
 use fs2::FileExt;
 use tempfile::NamedTempFile;
 
+use crate::allowlist::load_allowlist;
 use crate::cleaner::Removal;
 use crate::{
     CleaningSettings, HistoryEntry, Paths, compact_exits_file, identify_removals, load_exit_codes,
@@ -53,7 +54,8 @@ pub fn run_cleanup(
 
     let exit_codes = load_exit_codes(&paths.exits)?;
     let parsed = parse_history_file(&paths.history, &exit_codes)?;
-    let removals = identify_removals(&parsed, settings);
+    let allowlist = load_allowlist(&paths.allowlist)?;
+    let removals = identify_removals(&parsed, settings, allowlist.as_ref());
     let total_lines = parsed.entries.len();
     let drop_set = removals_set(&removals);
 

--- a/src/cleaner.rs
+++ b/src/cleaner.rs
@@ -45,7 +45,7 @@ pub fn identify_removals(
         .collect();
     out.sort_by_key(|r| r.line);
     if let Some(set) = allowlist {
-        out.retain(|r| !set.is_match(&r.command));
+        out.retain(|r| r.reason.starts_with("Secret pattern:") || !set.is_match(&r.command));
     }
     out
 }
@@ -388,5 +388,18 @@ mod tests {
         let allowlist = RegexSet::new(["^kubectl "]).unwrap();
         let with_list = identify_removals(&h, &CleaningSettings::default(), Some(&allowlist));
         assert!(with_list.is_empty());
+    }
+
+    #[test]
+    fn allowlist_does_not_suppress_secret_removals() {
+        // ^export matches, but the command contains a secret — must still be removed
+        let h = parse_with_exits(
+            ": 1:0;export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY\n",
+            &[("1", 0)],
+        );
+        let allowlist = RegexSet::new(["^export "]).unwrap();
+        let removals = identify_removals(&h, &CleaningSettings::default(), Some(&allowlist));
+        assert_eq!(removals.len(), 1);
+        assert!(removals[0].reason.starts_with("Secret pattern:"));
     }
 }

--- a/src/cleaner.rs
+++ b/src/cleaner.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use regex::RegexSet;
 use serde::Serialize;
 
 use crate::history::ParsedHistory;
@@ -15,7 +16,11 @@ pub struct Removal {
     pub command: String,
 }
 
-pub fn identify_removals(parsed: &ParsedHistory, settings: &CleaningSettings) -> Vec<Removal> {
+pub fn identify_removals(
+    parsed: &ParsedHistory,
+    settings: &CleaningSettings,
+    allowlist: Option<&RegexSet>,
+) -> Vec<Removal> {
     let mut removals: HashMap<usize, String> = HashMap::new();
     dedup_keep_newest(parsed, &mut removals);
     mark_secrets(parsed, &mut removals);
@@ -39,6 +44,9 @@ pub fn identify_removals(parsed: &ParsedHistory, settings: &CleaningSettings) ->
         })
         .collect();
     out.sort_by_key(|r| r.line);
+    if let Some(set) = allowlist {
+        out.retain(|r| !set.is_match(&r.command));
+    }
     out
 }
 
@@ -207,7 +215,7 @@ mod tests {
             ": 1:0;ls\n: 2:0;pwd\n: 3:0;ls\n: 4:0;ls\n",
             &[("1", 0), ("2", 0), ("3", 0), ("4", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         let lines: Vec<usize> = removals.iter().map(|r| r.line).collect();
         assert_eq!(lines, vec![0, 2]);
         assert!(removals.iter().all(|r| r.reason == "Duplicate"));
@@ -219,7 +227,7 @@ mod tests {
             ": 1:0;git statsu\n: 2:0;git status\n: 3:0;git status\n",
             &[("1", 1), ("2", 0), ("3", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         let hit = removals
             .iter()
             .any(|r| r.line == 0 && r.reason.contains("Failed similar"));
@@ -232,7 +240,7 @@ mod tests {
             ": 1:0;mise ins\n: 2:0;mise install\n: 3:0;mise install\n",
             &[("1", 1), ("2", 0), ("3", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         let hit = removals
             .iter()
             .any(|r| r.line == 0 && r.reason.contains("Failed prefix"));
@@ -242,7 +250,7 @@ mod tests {
     #[test]
     fn different_base_command_not_removed() {
         let h = parse_with_exits(": 1:0;ls -la\n: 2:0;git status\n", &[("1", 1), ("2", 0)]);
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert!(removals.is_empty());
     }
 
@@ -252,7 +260,7 @@ mod tests {
             ": 1:0;git push origin feature-1\n: 2:0;git push origin feature-2\n: 3:0;git push origin feature-2\n",
             &[("1", 1), ("2", 0), ("3", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         let flagged = removals
             .iter()
             .any(|r| r.line == 0 && r.reason.contains("Failed similar"));
@@ -265,7 +273,7 @@ mod tests {
             ": 1:0;git statsu\n: 2:0;git status\n: 3:0;git status\n",
             &[("1", 1), ("2", 0), ("3", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         let hit = removals
             .iter()
             .any(|r| r.line == 0 && r.reason.contains("Failed similar"));
@@ -311,7 +319,7 @@ mod tests {
             remove_rare: true,
             ..Default::default()
         };
-        let removals = identify_removals(&h, &s);
+        let removals = identify_removals(&h, &s, None);
         // statsu weighted=1.0, status weighted=2.0; 2.0 <= 1.0*3=3.0 → not removed
         let rare_removed = removals.iter().any(|r| r.reason.contains("Rare variant"));
         assert!(!rare_removed);
@@ -338,7 +346,7 @@ mod tests {
             remove_rare: true,
             ..Default::default()
         };
-        let removals = identify_removals(&h, &s);
+        let removals = identify_removals(&h, &s, None);
         let rare_removed = removals.iter().any(|r| r.reason.contains("Rare variant"));
         assert!(rare_removed);
     }
@@ -357,12 +365,28 @@ mod tests {
             remove_rare: true,
             ..Default::default()
         };
-        let removals = identify_removals(&h, &s);
+        let removals = identify_removals(&h, &s, None);
         let rare_lines: Vec<usize> = removals
             .iter()
             .filter(|r| r.reason.contains("Rare variant"))
             .map(|r| r.line)
             .collect();
         assert_eq!(rare_lines, vec![20]);
+    }
+
+    #[test]
+    fn allowlist_protects_matching_commands() {
+        // Without allowlist: duplicate kubectl is removed
+        let h = parse_with_exits(
+            ": 1:0;kubectl get pods\n: 2:0;kubectl get pods\n",
+            &[("1", 0), ("2", 0)],
+        );
+        let without = identify_removals(&h, &CleaningSettings::default(), None);
+        assert_eq!(without.len(), 1);
+
+        // With allowlist matching ^kubectl: nothing removed
+        let allowlist = RegexSet::new(["^kubectl "]).unwrap();
+        let with_list = identify_removals(&h, &CleaningSettings::default(), Some(&allowlist));
+        assert!(with_list.is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod allowlist;
 pub mod clean;
 pub mod cleaner;
 pub mod exits;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use zsh_clean_history::allowlist::load_allowlist;
 use zsh_clean_history::clean::{LockedHistory, run_cleanup};
 use zsh_clean_history::cleaner::Removal;
 use zsh_clean_history::{
@@ -98,7 +99,8 @@ fn explain(command: &str, cli: &Cli, paths: &Paths) -> Result<()> {
 
     let exit_codes = load_exit_codes(&paths.exits)?;
     let parsed = parse_history_file(&paths.history, &exit_codes)?;
-    let removals = identify_removals(&parsed, &settings);
+    let allowlist = load_allowlist(&paths.allowlist)?;
+    let removals = identify_removals(&parsed, &settings, allowlist.as_ref());
     let removal_map: HashMap<usize, &Removal> = removals.iter().map(|r| (r.line, r)).collect();
 
     let success_count = parsed.successful_counts.get(command).copied().unwrap_or(0);

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -6,6 +6,7 @@ pub struct Paths {
     pub history: PathBuf,
     pub exits: PathBuf,
     pub log: PathBuf,
+    pub allowlist: PathBuf,
 }
 
 impl Paths {
@@ -17,6 +18,7 @@ impl Paths {
             history: home.join(".zsh_history"),
             exits: home.join(".zsh_history_exits"),
             log: home.join(".zsh_history_cleanup.log"),
+            allowlist: home.join(".zsh_history_keep"),
         })
     }
 

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -84,7 +84,7 @@ mod tests {
             ": 1:0;export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY\n",
             &[("1", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert_eq!(removals.len(), 1);
         assert!(removals[0].reason.contains("AWS secret key"));
     }
@@ -95,7 +95,7 @@ mod tests {
             ": 1:0;export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n",
             &[("1", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert_eq!(removals.len(), 1);
         assert!(removals[0].reason.contains("AWS access key"));
     }
@@ -106,7 +106,7 @@ mod tests {
             ": 1:0;curl -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'\n",
             &[("1", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert_eq!(removals.len(), 1);
         assert!(removals[0].reason.contains("Bearer token"));
     }
@@ -117,7 +117,7 @@ mod tests {
             ": 1:0;curl -d 'username=admin&password=supersecret'\n",
             &[("1", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert_eq!(removals.len(), 1);
         assert!(removals[0].reason.contains("password"));
     }
@@ -128,7 +128,7 @@ mod tests {
             ": 1:0;curl 'https://api.example.com?api_key=mysecretvalue'\n",
             &[("1", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert_eq!(removals.len(), 1);
         assert!(removals[0].reason.contains("API key"));
     }
@@ -139,7 +139,7 @@ mod tests {
             ": 1:0;WEBHOOK_SECRET=aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899 ./deploy.sh\n",
             &[("1", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert_eq!(removals.len(), 1);
         assert!(removals[0].reason.contains("hex blob"));
     }
@@ -150,14 +150,14 @@ mod tests {
             ": 1:0;git reset --hard aabbccddeeff00112233445566778899aabbccdd\n",
             &[("1", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert!(removals.is_empty());
     }
 
     #[test]
     fn short_token_not_removed() {
         let h = parse(": 1:0;git config credential.token=x\n", &[("1", 0)]);
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert!(removals.is_empty());
     }
 
@@ -167,7 +167,7 @@ mod tests {
             ": 1:0;psql postgres://admin:s3cr3tpass@db.example.com/mydb\n",
             &[("1", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert_eq!(removals.len(), 1);
         assert!(removals[0].reason.contains("connection string"));
     }
@@ -175,7 +175,7 @@ mod tests {
     #[test]
     fn clean_command_not_removed() {
         let h = parse(": 1:0;git status\n", &[("1", 0)]);
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert!(removals.is_empty());
     }
 
@@ -185,7 +185,7 @@ mod tests {
             ": 1:0;export TOKEN=secret123abc\n: 2:0;export TOKEN=secret123abc\n",
             &[("1", 0), ("2", 0)],
         );
-        let removals = identify_removals(&h, &CleaningSettings::default());
+        let removals = identify_removals(&h, &CleaningSettings::default(), None);
         assert_eq!(removals.len(), 2);
         assert!(
             removals


### PR DESCRIPTION
## Motivation

Users want to permanently preserve specific history entries that the cleaner would otherwise remove. A file-based allowlist (`~/.zsh_history_keep`) gives explicit, persistent control over which commands are never pruned.

## Implementation information

- Added `~/.zsh_history_keep` file parsing: one pattern per line, `#` comments and blank lines ignored
- Allowlisted entries are preserved through the clean pass regardless of frequency/similarity scores
- Added a guard so allowlist membership never suppresses secret-pattern redaction — secrets in allowlisted entries are still redacted

Closes https://github.com/Automaat/zsh-clean-history/issues/33