### PR TITLE
ci(actions): add RustSec dependency audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,36 @@
+name: Audit
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/audit.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/audit.yml'
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+    - uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
+      with:
+        tool: cargo-audit
+    - name: cargo audit
+      run: cargo audit --deny warnings

--- a/.mise.toml
+++ b/.mise.toml
@@ -31,3 +31,7 @@ run = [
 [tasks.fmt]
 description = "Format Rust code"
 run = "cargo fmt --all"
+
+[tasks.audit]
+description = "Audit deps for RustSec advisories (cargo-audit required)"
+run = "cargo audit --deny warnings"


### PR DESCRIPTION
## Motivation

Dependency security status was unknown: Dependabot alerts are disabled
and CI had no RustSec audit gate, so vulnerable transitive crates could
ship unnoticed.

Closes #89

## Implementation information

- New `Audit` workflow runs `cargo audit --deny warnings`:
  - on PRs/pushes touching `Cargo.toml`/`Cargo.lock` (or the workflow
    itself)
  - weekly schedule (catches advisories published after merge)
  - manual `workflow_dispatch`
- `cargo-audit` installed via `taiki-e/install-action` (prebuilt
  binary, SHA-pinned, consistent with `release.yml`).
- `--deny warnings` also fails on unmaintained/yanked crates.
- Added `mise run audit` task for local runs.
- Renovate still handles update PRs; the audit gate handles
  vulnerability detection.

Verified `cargo audit` passes clean on the current `Cargo.lock`
(157 crate dependencies), so the gate is green on merge.

Note: enabling Dependabot alerts is a repo-settings change outside
this PR's scope.

## Supporting documentation

- Issue #89
- https://rustsec.org/