### PR TITLE
ci(release): tag after artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   prepare:
-    name: Bump version and tag
+    name: Prepare release
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.compute.outputs.version }}
@@ -30,14 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
-      - uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
-        with:
-          tool: cargo-edit
       - name: Compute new version
         id: compute
         env:
@@ -64,31 +60,15 @@ jobs:
           echo "version=$new" >> "$GITHUB_OUTPUT"
           echo "tag=v$new" >> "$GITHUB_OUTPUT"
           echo "Releasing v$new"
-      - name: Refuse if tag exists
+      - name: Refuse existing tag
         env:
           TAG: ${{ steps.compute.outputs.tag }}
         run: |
           set -euo pipefail
-          if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null; then
             echo "tag $TAG already exists" >&2
             exit 1
           fi
-      - name: Bump Cargo.toml
-        env:
-          NEW: ${{ steps.compute.outputs.version }}
-        run: cargo set-version "$NEW"
-      - name: Commit, tag, push
-        env:
-          TAG: ${{ steps.compute.outputs.tag }}
-        run: |
-          set -euo pipefail
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add Cargo.toml Cargo.lock
-          git commit -m "chore(release): $TAG"
-          git tag "$TAG"
-          git push origin HEAD:main
-          git push origin "$TAG"
 
   build:
     name: Build ${{ matrix.target }}
@@ -109,10 +89,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ needs.prepare.outputs.tag }}
+          ref: ${{ github.sha }}
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
+        with:
+          tool: cargo-edit
+      - name: Bump package version
+        env:
+          NEW: ${{ needs.prepare.outputs.version }}
+        run: cargo set-version "$NEW"
       - name: Add target
         run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -150,11 +137,55 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ needs.prepare.outputs.tag }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
+        with:
+          tool: cargo-edit
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
+      - name: Verify artifacts and tag
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null; then
+            echo "tag $TAG already exists" >&2
+            exit 1
+          fi
+          for target in \
+            aarch64-apple-darwin \
+            x86_64-apple-darwin \
+            x86_64-unknown-linux-gnu \
+            aarch64-unknown-linux-gnu
+          do
+            artifact="dist/zsh-clean-history-${VERSION}-${target}.tar.gz"
+            checksum="$artifact.sha256"
+            test -s "$artifact"
+            test -s "$checksum"
+            checksum_name="zsh-clean-history-${VERSION}-${target}.tar.gz.sha256"
+            (cd dist && shasum -a 256 -c "$checksum_name")
+          done
+      - name: Commit, tag, push
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          NEW: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          cargo set-version "$NEW"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore(release): $TAG"
+          git tag "$TAG"
+          git push --atomic origin HEAD:main "$TAG"
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,16 @@ clean-history-info
    - Implementation details
    - Supporting docs/issues
 
+## Releases
+
+1. Run the Release workflow from `main`
+2. `prepare` computes the version and refuses existing tags
+3. Build jobs bump the version locally and upload archives/checksums
+4. `release` verifies every artifact before pushing the version commit/tag
+5. `release` creates the GitHub release from verified artifacts
+
+Failed builds leave `main` and tags unchanged.
+
 ## Project structure
 
 ```


### PR DESCRIPTION
## Motivation

Release workflow pushed the version commit and tag before artifact builds finished. A build failure left main and tags advanced without a release.

## Implementation information

Prepare now only computes the version and checks remote tag absence. Build jobs bump the version locally before packaging. Publish downloads and verifies all expected artifacts/checksums, rechecks remote tag absence, then atomically pushes the version commit and tag before creating the GitHub release.

## Supporting documentation

Fixes Automaat/zsh-clean-history#91

> Changelog: ci(release): tag after artifacts