### PR TITLE
test(tooling): pin coverage runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+lcov.info
 Cargo.lock.bak
 *.backup
 .DS_Store

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,8 @@
 [tools]
-rust = "1.95.0"
+rust = { version = "1.95.0", components = "llvm-tools-preview" }
 shellcheck = "0.11.0"
 actionlint = "1.7.12"
+"cargo:cargo-llvm-cov" = "0.8.6"
 
 [tasks.build]
 description = "Build release binary"
@@ -16,7 +17,7 @@ description = "Run all tests"
 run = "cargo test --all-targets"
 
 [tasks.test-cov]
-description = "Run tests with coverage (cargo-llvm-cov required)"
+description = "Run tests with coverage"
 run = "cargo llvm-cov --all-targets --lcov --output-path lcov.info"
 
 [tasks.check]

--- a/tests/tooling.rs
+++ b/tests/tooling.rs
@@ -1,0 +1,12 @@
+use std::fs;
+
+#[test]
+fn mise_pins_coverage_runner() {
+    let config = fs::read_to_string(".mise.toml").unwrap();
+
+    assert!(config.contains(r#"rust = { version = "1.95.0", components = "llvm-tools-preview" }"#));
+    assert!(config.contains(r#""cargo:cargo-llvm-cov" = "0.8.6""#));
+    assert!(
+        config.contains(r#"run = "cargo llvm-cov --all-targets --lcov --output-path lcov.info""#)
+    );
+}


### PR DESCRIPTION
## Motivation

Fix #92. Make advertised coverage task work from clean checkout.

## Implementation information

Pin cargo-llvm-cov in mise tools. Add Rust llvm-tools component. Ignore generated lcov.info.

## Supporting documentation

Issue #92

> Changelog: test(tooling): pin coverage runner