### PR TITLE
build(build): drop stale cargo-dist config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,17 @@ clean-history-info
 
 ## Releases
 
+Releases use the custom `.github/workflows/release.yml` workflow only — there
+is no cargo-dist setup.
+
 1. Run the Release workflow from `main`
 2. `prepare` computes the version and refuses existing tags
 3. Build jobs bump the version locally and upload archives/checksums
 4. `release` verifies every artifact before pushing the version commit/tag
 5. `release` creates the GitHub release from verified artifacts
 
-Failed builds leave `main` and tags unchanged.
+Each archive bundles the binary, README, LICENSE, plugin, `completions/`, and
+`man/`. Failed builds leave `main` and tags unchanged.
 
 ## Project structure
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,18 +51,3 @@ codegen-units = 1
 strip = true
 
 [workspace]
-
-# cargo-dist
-[workspace.metadata.dist]
-cargo-dist-version = "0.28.0"
-ci = ["github"]
-installers = ["shell", "homebrew"]
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
-include = [
-    "completions/_zsh-clean-history",
-    "completions/zsh-clean-history.bash",
-    "completions/zsh-clean-history.fish",
-    "completions/zsh-clean-history.elv",
-    "completions/_zsh-clean-history.ps1",
-    "man/zsh-clean-history.1",
-]


### PR DESCRIPTION
## Motivation

`Cargo.toml` kept a `[workspace.metadata.dist]` block pinning
`cargo-dist-version = "0.28.0"`, but releases are produced by the custom
`.github/workflows/release.yml` workflow. The unused cargo-dist config
created ambiguity about the supported release path.

Closes #90.

> Changelog: skip

## Implementation information

- Removed the `[workspace.metadata.dist]` block from `Cargo.toml`. The
  custom workflow is the chosen and only release path.
- Documented this explicitly in `CONTRIBUTING.md`: releases use
  `release.yml` only, no cargo-dist, and each archive bundles the binary,
  README, LICENSE, plugin, `completions/`, and `man/`.

cargo-dist regeneration was rejected — the custom workflow already builds
the four targets, verifies checksums, and bundles completions/manpage; no
duplicated packaging logic remains.

## Supporting documentation

Issue #90 (parent #88).