### PR TITLE
ci(actions): add auto-merge-on-green workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,23 @@
+# Auto-merge PRs labeled "automerge" once all required checks pass.
+# Uses GitHub native auto-merge; requires repo setting allow_auto_merge=true.
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: contains(github.event.pull_request.labels.*.name, 'automerge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge on green
+        run: gh pr merge --auto --squash "${PR}"
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Motivation

Enable hands-off merging of approved PRs once CI is green, reducing manual merge overhead.

## Implementation information

Adds `.github/workflows/auto-merge.yml`. It triggers on pull_request events and, for PRs carrying the `automerge` label, enables GitHub native auto-merge (squash) via `gh pr merge --auto`. A release workflow already exists (`release.yml` builds artifacts, tags, and publishes GitHub releases), so no release workflow was added.

> Changelog: skip